### PR TITLE
CMake: Use GNUInstallDirs

### DIFF
--- a/dtmerge/CMakeLists.txt
+++ b/dtmerge/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
+include(GNUInstallDirs)
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")
 
 #set project name
@@ -8,5 +10,5 @@ project(dtmerge)
 #add executables
 add_executable(dtmerge dtmerge.c dtoverlay.c)
 target_link_libraries(dtmerge fdt)
-install(TARGETS dtmerge RUNTIME DESTINATION bin)
-install(FILES dtmerge.1 DESTINATION man/man1)
+install(TARGETS dtmerge RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES dtmerge.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)

--- a/otpset/CMakeLists.txt
+++ b/otpset/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 
+include(GNUInstallDirs)
+
 #set project name
 project(otpset)
 
 #add executables
-install(PROGRAMS otpset DESTINATION bin)
+install(PROGRAMS otpset DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/overlaycheck/CMakeLists.txt
+++ b/overlaycheck/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 
+include(GNUInstallDirs)
+
 #set project name
 project(overlaycheck)
 
 #add executables
-install(PROGRAMS overlaycheck DESTINATION bin)
-install(FILES overlaycheck_exclusions.txt DESTINATION bin)
+install(PROGRAMS overlaycheck DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES overlaycheck_exclusions.txt DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/ovmerge/CMakeLists.txt
+++ b/ovmerge/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 
+include(GNUInstallDirs)
+
 #set project name
 project(ovmerge)
 
 #add executables
-install(PROGRAMS ovmerge DESTINATION bin)
+install(PROGRAMS ovmerge DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/raspinfo/CMakeLists.txt
+++ b/raspinfo/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 
+include(GNUInstallDirs)
+
 #set project name
 project(raspinfo)
 
 #add executables
-install(PROGRAMS raspinfo DESTINATION bin)
+install(PROGRAMS raspinfo DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/vclog/CMakeLists.txt
+++ b/vclog/CMakeLists.txt
@@ -7,4 +7,4 @@ project(vclog)
 
 #add executables
 add_executable(vclog vcdbg.c)
-install(TARGETS vclog RUNTIME DESTINATION bin)
+install(TARGETS vclog RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Currently, dtmerge.1 gets installed into /usr/{local}/man/. The global path for manpages should be /usr/**share**/man.

This PR fixes that and also uses GNUInstallDirs for everything else. Functionally it should make no difference, but if shared objects get added later, it will save some headache when packaging everything.