### PR TITLE
vclog: Fix uninitialised variables warning

### DIFF
--- a/vclog/vcdbg.c
+++ b/vclog/vcdbg.c
@@ -280,7 +280,7 @@ int32_t main(int32_t argc, char *argv[]) {
       true; /*Set to true at first and changes at the end of the loop depending
                on whether the user decided to keep checking for new messages */
   const Individual_msg_hdr_t
-      *header_current_msg;  /*header of first message to parse*/
+      *header_current_msg = NULL;  /*header of first message to parse*/
   const size_t size_of_msg_header =
       sizeof(Individual_msg_hdr_t); /*Individual messages each have headers that
                                        are always the same size, which we will
@@ -567,7 +567,7 @@ static VC_region_requested_hdr_t *find_hdr_requested_log(
       val = toc->virtual->ptr_log_msg;
       break;
     default:
-      break;
+      return NULL;
   }
 
   /*This pointer is currently pointing to the physical memory of VC :


### PR DESCRIPTION
```
vcdbg.c: In function ‘find_hdr_requested_log’:
vcdbg.c:576:10: warning: ‘val’ may be used uninitialized [-Wmaybe-uninitialized]
  576 |   return correct_to_be_in_virtual_loc(toc, val);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
vcdbg.c:555:12: note: ‘val’ was declared here
  555 |   uint32_t val;
      |            ^~~
vcdbg.c: In function ‘main’:
vcdbg.c:356:9: warning: ‘header_current_msg’ may be used uninitialized [-Wmaybe-uninitialized]
  356 |         memcpy_vc_memory(start_circular_buff + offset_of_current_read_pos,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  357 |                          buffer_start + offset_of_current_read_pos,
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  358 |                          left_in_buffer);
      |                          ~~~~~~~~~~~~~~~
vcdbg.c:283:8: note: ‘header_current_msg’ was declared here
  283 |       *header_current_msg;  /*header of first message to parse*/
      |        ^~~~~~~~~~~~~~~~~~
```
The first is a logic bug.

The second looks like a spurious compiler diagnostic as `num_times_checked_if_new_logs = 0` and `print_logs = true` initially so header_current_msg will always be initialised before being used.

But initialise it to NULL to keep compiler happy