### PR TITLE
ovmerge: Allow it to run on 32-bit Perls

### DIFF
--- a/ovmerge/ovmerge
+++ b/ovmerge/ovmerge
@@ -1885,7 +1885,11 @@ sub get_labels
 sub integer_value
 {
 	my ($value, $size) = @_;
-	my %masks = (1=>0xff, 2=>0xffff, 4=>0xffffffff, 8=>0xffffffffffffffff);
+	# The following line should say '8=>0xffffffffffffffff', but this upsets
+	# builds of Perl with ivsize=4. This won't give the correct result for
+	# large values but Perl will already have rejected them due to integer
+	# overflow.
+	my %masks = (1=>0xff, 2=>0xffff, 4=>0xffffffff, 8=>-1);
 	return undef if (!defined $value);
 	if ($value =~ /^(y|yes|on|true|down)?$/)
 	{


### PR DESCRIPTION
Perl can be configured at build time to support 64-bit integers - ivsize=8 - even on 32-bit platforms. The Raspberry Pi Perl builds are configured this way but some aren't, causing interpreter errors on the 64-bit mask value 0xffffffffffffffff. Replacing this with a -1 has no negative effect when ivsize=8, and it allows the tool to run when ivsize=4 (without supporting values > 32-bit).

See: #23