### PR TITLE
vcdbg: Increase boundary to work with newer glibc

### DIFF
--- a/vclog/vcdbg.c
+++ b/vclog/vcdbg.c
@@ -26,7 +26,7 @@
   Typedef & Enums & structs & Const
 *******************************************************************************/
 
-int boundary = 8; /*memory boundary in relation to counting how misaligned
+int boundary = 16; /*memory boundary in relation to counting how misaligned
                            an address is from this boundary*/
 
 bool continuously_check_logs =


### PR DESCRIPTION
Reported by HiassofT

vclog -m is dying with a bus error on RPi4 / LE master since we updated glibc to 2.37. glibc switched to simd optimized memcpy
https://sourceware.org/git/?p=glibc.git;a=commit;h=e6f3fe362f1aab78b1448d69ecdbd9e3872636d3 and for whatever reason it doesn't seem to be happy with the 128bit access to the 64bit aligned address from your mmap'ed memory region - is that maybe iomem? (D_q is a define for q3, src a define for x1

Program received signal SIGBUS, Bus error.
__memcpy_generic () at ../sysdeps/aarch64/multiarch/../memcpy.S:155 155		ldr	D_q, [src]
(gdb) where
    dest@entry=0x7fadcd4014 "\305\300 \001", src=0x7fadd54168 "",
    src@entry=0x7fadd54164 "\305\300 \001", n=<optimized out>, n@entry=376444)
    at /home/hias/libreelec/libreelec-master/build.LibreELEC-RPi4.aarch64-12.0-devel/build/bcm2835-utils-5db3e694d27431403bebb13404f5d85899b571e0/vclog/vcdbg.c:742
    at /home/hias/libreelec/libreelec-master/build.LibreELEC-RPi4.aarch64-12.0-devel/build/bcm2835-utils-5db3e694d27431403bebb13404f5d85899b571e0/vclog/vcdbg.c:267
(gdb) up
    dest@entry=0x7fadcd4014 "\305\300 \001", src=0x7fadd54168 "",
    src@entry=0x7fadd54164 "\305\300 \001", n=<optimized out>, n@entry=376444)
    at /home/hias/libreelec/libreelec-master/build.LibreELEC-RPi4.aarch64-12.0-devel/build/bcm2835-utils-5db3e694d27431403bebb13404f5d85899b571e0/vclog/vcdbg.c:742
742	    memcpy(dest, src, bytes_to_memcpy);
(gdb) p dest
$1 = 0x7fadcd4018 ""
(gdb) p src
$2 = 0x7fadd54168 ""
(gdb) p bytes_to_memcpy
$3 = 376440
(gdb) down
155		ldr	D_q, [src]
(gdb) info registers
x0             0x7fadcd4018        548376756248
x1             0x7fadd54168        548377280872