### PR TITLE
Add dtoverlay and dtparam from the userland repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A collection of scripts and simple applications
 
 * [dtmerge](dtmerge/) - A tool for applying compiled DT overlays (`*.dtbo`) to base Device
-    Tree files (`*.dtb`)
+    Tree files (`*.dtb`). Also includes the `dtoverlay` and `dtparam` utilities.
 * [otpset](otpset/) - A short script to help with reading and setting the customer OTP
     bits.
 * [overlaycheck](overlaycheck/) - A tool for validating the overlay files and README in a

--- a/dtmerge/CMakeLists.txt
+++ b/dtmerge/CMakeLists.txt
@@ -2,13 +2,31 @@ cmake_minimum_required(VERSION 3.10)
 
 include(GNUInstallDirs)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")
-
 #set project name
 project(dtmerge)
 
-#add executables
-add_executable(dtmerge dtmerge.c dtoverlay.c)
-target_link_libraries(dtmerge fdt)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+
+if (CMAKE_COMPILER_IS_GNUCC)
+   add_definitions (-ffunction-sections)
+endif ()
+
+add_library (dtovl ${STATIC} dtoverlay.c)
+target_link_libraries(dtovl fdt)
+
+add_executable(dtmerge dtmerge.c)
+target_link_libraries(dtmerge dtovl)
 install(TARGETS dtmerge RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES dtmerge.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+
+add_executable(dtoverlay dtoverlay_main.c utils.c)
+target_link_libraries(dtoverlay dtovl)
+install(TARGETS dtoverlay RUNTIME DESTINATION bin)
+install(FILES dtoverlay.1 DESTINATION man/man1)
+
+add_custom_command(TARGET dtoverlay POST_BUILD COMMAND ln;-sf;dtoverlay;dtparam)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dtparam DESTINATION bin)
+install(FILES dtparam.1 DESTINATION man/man1)
+
+set(DTOVERLAY_SCRIPTS dtoverlay-pre dtoverlay-post)
+install(PROGRAMS ${DTOVERLAY_SCRIPTS} DESTINATION bin)

--- a/dtmerge/README.md
+++ b/dtmerge/README.md
@@ -1,8 +1,11 @@
 
-# dtmerge
+# dtmerge, dtoverlay and dtparam
 
 dtmerge is a tool for applying pre-compiled overlays (`*.dtbo` files) to a
 base Device Tree file (`*.dtb`).
+
+dtoverlay is a tool for applying pre-compiled overlays to a live system.
+dtparam is a tool for applying paramaters of the base Device Tree of a live system.
 
 **Build Instructions**
 
@@ -23,4 +26,47 @@ Usage:
   where <options> is any of:
     -d      Enable debug output
     -h      Show this help message
+```
+```
+Usage:
+  dtoverlay <overlay> [<param>=<val>...]
+                           Add an overlay (with parameters)
+  dtoverlay -D             Dry-run (prepare overlay, but don't apply -
+                           save it as dry-run.dtbo)
+  dtoverlay -r [<overlay>] Remove an overlay (by name, index or the last)
+  dtoverlay -R [<overlay>] Remove from an overlay (by name, index or all)
+  dtoverlay -l             List active overlays/params
+  dtoverlay -a             List all overlays (marking the active)
+  dtoverlay -h             Show this usage message
+  dtoverlay -h <overlay>   Display help on an overlay
+  dtoverlay -h <overlay> <param>..  Or its parameters
+    where <overlay> is the name of an overlay or 'dtparam' for dtparams
+Options applicable to most variants:
+    -d <dir>        Specify an alternate location for the overlays
+                    (defaults to /boot/overlays or /flash/overlays)
+    -p <string>     Force a compatible string for the platform
+    -v              Verbose operation
+
+Adding or removing overlays and parameters requires root privileges.
+```
+```
+Usage:
+  dtparam                Display help on all parameters
+  dtparam <param>=<val>...
+                         Add an overlay (with parameters)
+  dtparam -D             Dry-run (prepare overlay, but don't apply -
+                         save it as dry-run.dtbo)
+  dtparam -r [<idx>]     Remove an overlay (by index, or the last)
+  dtparam -R [<idx>]     Remove from an overlay (by index, or all)
+  dtparam -l             List active overlays/dtparams
+  dtparam -a             List all overlays/dtparams (marking the active)
+  dtparam -h             Show this usage message
+  dtparam -h <param>...  Display help on the listed parameters
+Options applicable to most variants:
+    -d <dir>        Specify an alternate location for the overlays
+                    (defaults to /boot/overlays or /flash/overlays)
+    -p <string>     Force a compatible string for the platform
+    -v              Verbose operation
+
+Adding or removing overlays and parameters requires root privileges.
 ```

--- a/dtmerge/dtoverlay-post
+++ b/dtmerge/dtoverlay-post
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if ! hash lxpanelctl 2> /dev/null; then
+	exit 0
+fi
+
+CMD="lxpanelctl command volumealsabt start > /dev/null"
+
+for PID in $(pgrep -x lxpanel); do
+	eval "$(grep -z "DISPLAY=" "/proc/$PID/environ" | tr -d '\0')"
+	user="$(ps -p "$PID" -o uname=)"
+	su "$user" -c "$CMD"
+done

--- a/dtmerge/dtoverlay-pre
+++ b/dtmerge/dtoverlay-pre
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if ! hash lxpanelctl 2> /dev/null; then
+	exit 0
+fi
+
+CMD="lxpanelctl command volumealsabt stop >/dev/null"
+
+for PID in $(pgrep -x lxpanel); do
+	eval "$(grep -z "DISPLAY=" "/proc/$PID/environ" | tr -d '\0')"
+	user="$(ps -p "$PID" -o uname=)"
+	su "$user" -c "$CMD"
+done

--- a/dtmerge/dtoverlay.1
+++ b/dtmerge/dtoverlay.1
@@ -1,0 +1,153 @@
+.TH DTOVERLAY 1
+.
+.SH NAME
+dtoverlay \- load a device-tree overlay
+.
+.
+.SH SYNOPSIS
+.SY dtoverlay
+.OP \-d dir
+.OP \-p string
+.OP \-v
+.OP \-D
+.OP \-r
+.OP \-R
+.OP \-l
+.OP \-a
+.RI [ overlay " [" param=val \|.\|.\|.]]
+.YS
+.
+.SY dtoverlay
+.B \-h
+.RI [ overlay " [" param ]]
+.YS
+.
+.
+.SH DESCRIPTION
+.B dtoverlay
+is a command line utility for manipulating the system's runtime device-tree by
+adding or removing overlays.
+It can also customize the base device-tree or overlays by setting parameters
+within them.
+See
+.B [DTREE]
+for more information.
+.
+.PP
+By default, without the
+.B -r
+or
+.B -R
+options, the application adds the specified overlay. Manipulation of
+active device-tree overlays usually requires root privileges.
+.
+.
+.SH OPTIONS
+.
+.TP
+.BR \-a
+Lists all defined device-tree overlays, placing a "*" next to those that are
+currently loaded.
+.
+.TP
+.BR \-d " \fIdir\fR"
+Specifies an alternate location path from which to load overlays. The utility
+defaults to "/boot/overlays" or "/flash/overlays".
+.
+.TP
+.BR \-D
+Dry-run; prepares the specified overlay but doesn't apply it. The resulting
+prepared overlay is saved as "dry-run.dtbo".
+.
+.TP
+.BR \-h [\fIoverlay\fR] [\fIparam\fR]
+If given without
+.I overlay
+or
+.I param
+displays help on the application overall. If
+.I overlay
+is specified, prints help on that overlay. Finally, if
+.I param
+is also specified, prints help on that parameter of the overlay. To query
+parameters on the base overlay, specify "dtparam" as the
+.IR overlay .
+.
+.TP
+.BR \-l
+Lists all currently loaded device-tree overlays, in the order they were loaded.
+This also specifies the index of each overlay.
+.
+.TP
+.BR \-p " \fIstring\fR"
+Override the platform's "compatible" string, normally read from
+"/proc/device-tree/compatible". This is used with the overlay map to determine
+which platform-specific overlay to read (if necessary).
+.
+.TP
+.BR \-r
+Remove overlay. With this option, the utility will remove the specified
+overlay. If no overlay is given, the last overlay loaded will be removed.
+Overlays can be specified by name or by index.
+.
+.TP
+.BR \-R
+Remove the specified overlay, and all subsequent overlays that were loaded
+after it. If no overlay is given, all overlays will be removed. Overlays can
+be specified by name or by index.
+.
+.TP
+.BR \-v
+Verbose operation; the utility will produce more output.
+.
+.
+.SH EXAMPLES
+.
+.TP
+.B sudo dtoverlay w1-gpio
+Load the w1-gpio overlay (to enable Dallas 1-Wire on GPIO4). Note that root
+privileges are usually required for manipulating the device-tree overlays
+(hence, sudo in the example).
+.
+.TP
+.B dtoverlay -l
+Show the loaded overlays.
+.
+.TP
+.B sudo dtoverlay -r
+Remove the last loaded overlay.
+.
+.TP
+.B sudo dtoverlay gpio-shutdown gpio_pin=7 active_low=0 gpio_pull=down
+Load the gpio-shutdown overlay specifying that it should pull GPIO7 down and
+monitor it for a rising edge to initiate shutdown.
+.
+.TP
+.B dtoverlay -h gpio-shutdown
+Display help for the gpio-shutdown overlay
+.
+.TP
+.B sudo dtoverlay -r gpio-shutdown
+Remove the gpio-shutdown overlay, wherever it is in the load order.
+.
+.
+.SH HOOKS
+.B dtoverlay
+attempts to call two executables (shell scripts by default) during its
+operation:
+.B dtoverlay-pre
+prior to making device-tree modifications, and
+.B dtoverlay-post
+afterwards. Each executable is optional and will be ignored if not present.
+.
+.
+.SH SEE ALSO
+.BR dtparam (1),
+.BR dtmerge (1),
+.B [DTREE]
+.
+.
+.SH REFERENCES
+.TP
+.B [DTREE]
+https://www.raspberrypi.org/documentation/configuration/device-tree.md

--- a/dtmerge/dtoverlay.2
+++ b/dtmerge/dtoverlay.2
@@ -1,0 +1,153 @@
+.TH DTOVERLAY 1
+.
+.SH NAME
+dtoverlay \- load a device-tree overlay
+.
+.
+.SH SYNOPSIS
+.SY dtoverlay
+.OP \-d dir
+.OP \-p string
+.OP \-v
+.OP \-D
+.OP \-r
+.OP \-R
+.OP \-l
+.OP \-a
+.RI [ overlay " [" param=val \|.\|.\|.]]
+.YS
+.
+.SY dtoverlay
+.B \-h
+.RI [ overlay " [" param ]]
+.YS
+.
+.
+.SH DESCRIPTION
+.B dtoverlay
+is a command line utility for manipulating the system's runtime device-tree by
+adding or removing overlays.
+It can also customize the base device-tree or overlays by setting parameters
+within them.
+See
+.B [DTREE]
+for more information.
+.
+.PP
+By default, without the
+.B -r
+or
+.B -R
+options, the application adds the specified overlay. Manipulation of
+active device-tree overlays usually requires root privileges.
+.
+.
+.SH OPTIONS
+.
+.TP
+.BR \-a
+Lists all defined device-tree overlays, placing a "*" next to those that are
+currently loaded.
+.
+.TP
+.BR \-d " \fIdir\fR"
+Specifies an alternate location path from which to load overlays. The utility
+defaults to "/boot/overlays" or "/flash/overlays".
+.
+.TP
+.BR \-D
+Dry-run; prepares the specified overlay but doesn't apply it. The resulting
+prepared overlay is saved as "dry-run.dtbo".
+.
+.TP
+.BR \-h [\fIoverlay\fR] [\fIparam\fR]
+If given without
+.I overlay
+or
+.I param
+displays help on the application overall. If
+.I overlay
+is specified, prints help on that overlay. Finally, if
+.I param
+is also specified, prints help on that parameter of the overlay. To query
+parameters on the base overlay, specify "dtparam" as the
+.IR overlay .
+.
+.TP
+.BR \-l
+Lists all currently loaded device-tree overlays, in the order they were loaded.
+This also specifies the index of each overlay.
+.
+.TP
+.BR \-p " \fIstring\fR"
+Override the platform's "compatible" string, normally read from
+"/proc/device-tree/compatible". This is used with the overlay map to determine
+which platform-specific overlay to read (if necessary).
+.
+.TP
+.BR \-r
+Remove overlay. With this option, the utility will remove the specified
+overlay. If no overlay is given, the last overlay loaded will be removed.
+Overlays can be specified by name or by index.
+.
+.TP
+.BR \-R
+Remove the specified overlay, and all subsequent overlays that were loaded
+after it. If no overlay is given, all overlays will be removed. Overlays can
+be specified by name or by index.
+.
+.TP
+.BR \-v
+Verbose operation; the utility will produce more output.
+.
+.
+.SH EXAMPLES
+.
+.TP
+.B sudo dtoverlay w1-gpio
+Load the w1-gpio overlay (to enable Dallas 1-Wire on GPIO4). Note that root
+privileges are usually required for manipulating the device-tree overlays
+(hence, sudo in the example).
+.
+.TP
+.B dtoverlay -l
+Show the loaded overlays.
+.
+.TP
+.B sudo dtoverlay -r
+Remove the last loaded overlay.
+.
+.TP
+.B sudo dtoverlay gpio-shutdown gpio_pin=7 active_low=0 gpio_pull=down
+Load the gpio-shutdown overlay specifying that it should pull GPIO7 down and
+monitor it for a rising edge to initiate shutdown.
+.
+.TP
+.B dtoverlay -h gpio-shutdown
+Display help for the gpio-shutdown overlay
+.
+.TP
+.B sudo dtoverlay -r gpio-shutdown
+Remove the gpio-shutdown overlay, wherever it is in the load order.
+.
+.
+.SH HOOKS
+.B dtoverlay
+attempts to call two executables (shell scripts by default) during its
+operation:
+.B dtoverlay-pre
+prior to making device-tree modifications, and
+.B dtoverlay-post
+afterwards. Each executable is optional and will be ignored if not present.
+.
+.
+.SH SEE ALSO
+.BR dtparam (1),
+.BR dtmerge (1),
+.B [DTREE]
+.
+.
+.SH REFERENCES
+.TP
+.B [DTREE]
+https://www.raspberrypi.org/documentation/configuration/device-tree.md

--- a/dtmerge/dtoverlay.c
+++ b/dtmerge/dtoverlay.c
@@ -220,6 +220,16 @@ int dtoverlay_find_node(DTBLOB_T *dtb, const char *node_path, int path_len)
    return fdt_path_offset_namelen(dtb->fdt, node_path, path_len);
 }
 
+int dtoverlay_first_subnode(DTBLOB_T *dtb, int node_off)
+{
+    return fdt_first_subnode(dtb->fdt, node_off);
+}
+
+int dtoverlay_next_subnode(DTBLOB_T *dtb, int subnode_off)
+{
+    return fdt_next_subnode(dtb->fdt, subnode_off);
+}
+
 // Returns 0 on success, otherwise <0 error code
 int dtoverlay_set_node_properties(DTBLOB_T *dtb, const char *node_path,
                                   DTOVERLAY_PARAM_T *properties,

--- a/dtmerge/dtoverlay.h
+++ b/dtmerge/dtoverlay.h
@@ -114,6 +114,10 @@ int dtoverlay_delete_node(DTBLOB_T *dtb, const char *node_name, int path_len);
 
 int dtoverlay_find_node(DTBLOB_T *dtb, const char *node_path, int path_len);
 
+
+int dtoverlay_first_subnode(DTBLOB_T *dtb, int node_off);
+int dtoverlay_next_subnode(DTBLOB_T *dtb, int subnode_off);
+
 int dtoverlay_set_node_properties(DTBLOB_T *dtb, const char *node_path,
                                   DTOVERLAY_PARAM_T *properties,
                                   unsigned int num_properties);

--- a/dtmerge/dtoverlay_main.c
+++ b/dtmerge/dtoverlay_main.c
@@ -1,0 +1,1140 @@
+/*
+Copyright (c) 2016 Raspberry Pi (Trading) Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <errno.h>
+
+#include <libfdt.h>
+
+#include "dtoverlay.h"
+#include "utils.h"
+
+
+#define CFG_DIR_1 "/sys/kernel/config"
+#define CFG_DIR_2 "/config"
+#define DT_SUBDIR "/device-tree"
+#define WORK_DIR "/tmp/.dtoverlays"
+#define OVERLAY_SRC_SUBDIR "overlays"
+#define README_FILE "README"
+#define DT_OVERLAYS_SUBDIR "overlays"
+#define DTOVERLAY_PATH_MAX 128
+#define DIR_MODE 0755
+
+
+enum {
+    OPT_ADD,
+    OPT_REMOVE,
+    OPT_REMOVE_FROM,
+    OPT_LIST,
+    OPT_LIST_ALL,
+    OPT_HELP
+};
+
+static const char *boot_dirs[] =
+{
+#ifdef FORCE_BOOT_DIR
+    FORCE_BOOT_DIR,
+#else
+    "/boot/firmware",
+    "/boot",
+    "/flash",
+#ifdef OTHER_BOOT_DIR
+    OTHER_BOOT_DIR,
+#endif
+#endif
+    NULL /* Terminator */
+};
+
+typedef struct state_struct
+{
+    int count;
+    struct dirent **namelist;
+} STATE_T;
+
+static int dtoverlay_add(STATE_T *state, const char *overlay,
+                         int argc, const char **argv);
+static int dtoverlay_remove(STATE_T *state, const char *overlay, int and_later);
+static int dtoverlay_list(STATE_T *state);
+static int dtoverlay_list_all(STATE_T *state);
+static void usage(void);
+static void root_check(void);
+
+static void overlay_help(const char *overlay, const char **params);
+
+static int apply_overlay(const char *overlay_file, const char *overlay);
+static int overlay_applied(const char *overlay_dir);
+
+static STATE_T *read_state(const char *dir);
+static void free_state(STATE_T *state);
+
+const char *cmd_name;
+
+const char *work_dir = WORK_DIR;
+const char *overlay_src_dir;
+const char *dt_overlays_dir;
+const char *error_file = NULL;
+const char *platform_string;
+int platform_string_len;
+int dry_run = 0;
+
+int main(int argc, const char **argv)
+{
+    int argn = 1;
+    int opt = OPT_ADD;
+    int is_dtparam;
+    const char *overlay = NULL;
+    const char **params = NULL;
+    int ret = 0;
+    STATE_T *state = NULL;
+    const char *cfg_dir;
+
+    cmd_name = argv[0];
+    if (strrchr(cmd_name, '/'))
+        cmd_name = strrchr(cmd_name, '/') + 1;
+    is_dtparam = (strcmp(cmd_name, "dtparam") == 0);
+
+    while ((argn < argc) && (argv[argn][0] == '-'))
+    {
+        const char *arg = argv[argn++];
+        if (strcmp(arg, "-r") == 0)
+        {
+            if (opt != OPT_ADD)
+                usage();
+            opt = OPT_REMOVE;
+        }
+        else if (strcmp(arg, "-R") == 0)
+        {
+            if (opt != OPT_ADD)
+                usage();
+            opt = OPT_REMOVE_FROM;
+        }
+        else if (strcmp(arg, "-D") == 0)
+        {
+            if (opt != OPT_ADD)
+                usage();
+            dry_run = 1;
+            work_dir = ".";
+        }
+        else if ((strcmp(arg, "-l") == 0) ||
+                 (strcmp(arg, "--list") == 0))
+        {
+            if (opt != OPT_ADD)
+                usage();
+            opt = OPT_LIST;
+        }
+        else if ((strcmp(arg, "-a") == 0) ||
+                 (strcmp(arg, "--listall") == 0) ||
+                 (strcmp(arg, "--all") == 0))
+        {
+            if (opt != OPT_ADD)
+                usage();
+            opt = OPT_LIST_ALL;
+        }
+        else if (strcmp(arg, "-d") == 0)
+        {
+            if (argn == argc)
+                usage();
+            overlay_src_dir = argv[argn++];
+        }
+        else if (strcmp(arg, "-p") == 0)
+        {
+            if (argn == argc)
+                usage();
+            platform_string = argv[argn++];
+            platform_string_len = strlen(platform_string) + 1;
+        }
+        else if (strcmp(arg, "-v") == 0)
+        {
+            opt_verbose = 1;
+        }
+        else if (strcmp(arg, "-h") == 0)
+        {
+            opt = OPT_HELP;
+        }
+        else
+        {
+            fprintf(stderr, "* unknown option '%s'\n", arg);
+            usage();
+        }
+    }
+
+    if ((opt == OPT_ADD) || (opt == OPT_REMOVE) ||
+        (opt == OPT_REMOVE_FROM) || (opt == OPT_HELP))
+    {
+        if ((argn == argc) &&
+            ((!is_dtparam &&
+              ((opt == OPT_ADD) || (opt == OPT_HELP))) ||
+             (is_dtparam && (opt == OPT_HELP))))
+            usage();
+        if (is_dtparam && (opt == OPT_ADD) && (argn == argc))
+            opt = OPT_HELP;
+        if (is_dtparam &&
+            ((opt == OPT_ADD) || (opt == OPT_HELP)))
+            overlay = "dtparam";
+        else if (argn < argc)
+            overlay = argv[argn++];
+    }
+
+    if ((opt == OPT_HELP) && (argn < argc))
+    {
+        params = &argv[argn];
+        argn = argc;
+    }
+
+    if ((opt != OPT_ADD) && (argn != argc))
+        usage();
+
+    dtoverlay_enable_debug(opt_verbose);
+
+    if (!overlay_src_dir)
+    {
+        /* Find the overlays and README */
+        const char *os_prefix;
+        int i;
+
+        /* Check for an os_prefix value */
+        os_prefix = read_file_as_string("/proc/device-tree/chosen/os_prefix",
+                                        NULL);
+        if (!os_prefix)
+            os_prefix = "";
+
+        for (i = 0; boot_dirs[i]; i++)
+        {
+            overlay_src_dir = sprintf_dup("%s/%s" OVERLAY_SRC_SUBDIR,
+                                          boot_dirs[i], os_prefix);
+            if (dir_exists(overlay_src_dir))
+                break;
+            free_string(overlay_src_dir);
+            overlay_src_dir = NULL;
+        }
+
+        if (!overlay_src_dir)
+            fatal_error("Failed to find overlays directory");
+    }
+
+    if (opt == OPT_HELP)
+    {
+        overlay_help(overlay, params);
+        goto orderly_exit;
+    }
+
+    if (!dir_exists(work_dir))
+    {
+        if (mkdir(work_dir, DIR_MODE) != 0)
+            fatal_error("Failed to create '%s' - %d", work_dir, errno);
+    }
+
+    error_file = sprintf_dup("%s/%s", work_dir, "error.dtb");
+
+    cfg_dir = CFG_DIR_1 DT_SUBDIR;
+    if (!dry_run && !dir_exists(cfg_dir))
+    {
+        root_check();
+
+        cfg_dir = CFG_DIR_2;
+        if (!dir_exists(cfg_dir))
+        {
+            if (mkdir(cfg_dir, DIR_MODE) != 0)
+                fatal_error("Failed to create '%s' - %d", cfg_dir, errno);
+        }
+
+        cfg_dir = CFG_DIR_2 DT_SUBDIR;
+        if (!dir_exists(cfg_dir) &&
+            (run_cmd("mount -t configfs none '%s'", cfg_dir) != 0))
+            fatal_error("Failed to mount configfs - %d", errno);
+    }
+
+    if (!platform_string)
+        platform_string = read_file_as_string("/proc/device-tree/compatible",
+                                              &platform_string_len);
+
+    if (platform_string)
+        dtoverlay_init_map(overlay_src_dir, platform_string, platform_string_len);
+
+    if (!dry_run)
+    {
+        dt_overlays_dir = sprintf_dup("%s/%s", cfg_dir, DT_OVERLAYS_SUBDIR);
+        if (!dir_exists(dt_overlays_dir))
+            fatal_error("configfs overlays folder not found - incompatible kernel");
+
+        state = read_state(work_dir);
+        if (!state)
+            fatal_error("Failed to read state");
+    }
+
+    switch (opt)
+    {
+    case OPT_ADD:
+    case OPT_REMOVE:
+    case OPT_REMOVE_FROM:
+        if (!dry_run)
+        {
+            root_check();
+            run_cmd("which dtoverlay-pre >/dev/null 2>&1 && dtoverlay-pre");
+        }
+        break;
+    default:
+        break;
+    }
+
+    switch (opt)
+    {
+    case OPT_ADD:
+        ret = dtoverlay_add(state, overlay, argc - argn, argv + argn);
+        break;
+    case OPT_REMOVE:
+        ret = dtoverlay_remove(state, overlay, 0);
+        break;
+    case OPT_REMOVE_FROM:
+        ret = dtoverlay_remove(state, overlay, 1);
+        break;
+    case OPT_LIST:
+        ret = dtoverlay_list(state);
+        break;
+    case OPT_LIST_ALL:
+        ret = dtoverlay_list_all(state);
+        break;
+    default:
+        ret = 1;
+        break;
+    }
+
+    switch (opt)
+    {
+    case OPT_ADD:
+    case OPT_REMOVE:
+    case OPT_REMOVE_FROM:
+        if (!dry_run)
+            run_cmd("which dtoverlay-post >/dev/null 2>&1 && dtoverlay-post");
+        break;
+    default:
+        break;
+    }
+
+orderly_exit:
+    if (state)
+        free_state(state);
+    free_strings();
+
+    if ((ret == 0) && error_file)
+        unlink(error_file);
+
+    return ret;
+}
+
+int dtparam_callback(int override_type, const char *override_value,
+                     DTBLOB_T *dtb, int node_off,
+                     const char *prop_name, int target_phandle,
+                     int target_off, int target_size,
+                     void *callback_state)
+{
+    STRING_VEC_T *used_props = callback_state;
+    char prop_id[80];
+    int err;
+
+    err = dtoverlay_override_one_target(override_type,
+                                        override_value,
+                                        dtb, node_off,
+                                        prop_name, target_phandle,
+                                        target_off, target_size,
+                                        callback_state);
+
+    if ((err == 0) && (target_phandle != 0))
+    {
+        if (snprintf(prop_id, sizeof(prop_id), "%08x%s", target_phandle,
+                     prop_name) < 0)
+            err = FDT_ERR_INTERNAL;
+        else if (string_vec_find(used_props, prop_id, 0) < 0)
+            string_vec_add(used_props, prop_id, 0);
+    }
+
+    return err;
+}
+
+// Returns 0 on success, -ve for fatal errors and +ve for non-fatal errors
+int dtparam_apply(DTBLOB_T *dtb, const char *override_name,
+                  const char *override_data, int data_len,
+                  const char *override_value, STRING_VEC_T *used_props)
+{
+    void *data;
+    int err;
+
+    /* Copy the override data in case it moves */
+    data = malloc(data_len);
+    if (data)
+    {
+        memcpy(data, override_data, data_len);
+        err = dtoverlay_foreach_override_target(dtb, override_name,
+                                                data, data_len,
+                                                override_value,
+                                                dtparam_callback,
+                                                used_props);
+        free(data);
+    }
+    else
+    {
+        dtoverlay_error("out of memory");
+        err = NON_FATAL(FDT_ERR_NOSPACE);
+    }
+
+    return err;
+}
+
+static int apply_parameter(DTBLOB_T *overlay_dtb, const char *arg, int is_dtparam,
+                           STRING_VEC_T *used_props, char **param_string)
+{
+    const char *param_val = strchr(arg, '=');
+    const char *param, *override;
+    char *p = NULL;
+    int override_len;
+    int err = 0;
+
+    if (param_val)
+    {
+        int len = (param_val - arg);
+        p = sprintf_dup("%.*s", len, arg);
+        param = p;
+        param_val++;
+    }
+    else
+    {
+        /* Use the default parameter value - true */
+        param = arg;
+        param_val = "true";
+    }
+
+    override = dtoverlay_find_override(overlay_dtb, param, &override_len);
+
+    if (!override)
+        return error("Unknown parameter '%s'", param);
+
+    if (is_dtparam)
+        err = dtparam_apply(overlay_dtb, param,
+                            override, override_len,
+                            param_val, used_props);
+    else
+        err = dtoverlay_apply_override(overlay_dtb, param,
+                                       override, override_len,
+                                       param_val);
+    if (err != 0)
+        return error("Failed to set %s=%s", param, param_val);
+
+    *param_string = sprintf_dup("%s %s=%s",
+                                *param_string ? *param_string : "",
+                                param, param_val);
+
+    free_string(p);
+
+    return 0;
+}
+
+static int dtoverlay_add(STATE_T *state, const char *overlay,
+                         int argc, const char **argv)
+{
+    const char *overlay_name;
+    const char *overlay_file;
+    const char *overrides = NULL;
+    char *param_string = NULL;
+    int is_dtparam;
+    DTBLOB_T *base_dtb = NULL;
+    DTBLOB_T *overlay_dtb;
+    STRING_VEC_T used_props;
+    int err;
+    int len;
+    int i;
+
+    len = strlen(overlay) - 5;
+    is_dtparam = (strcmp(overlay, "dtparam") == 0);
+    if (is_dtparam)
+    {
+        /* Convert /proc/device-tree to a .dtb and load it */
+        overlay_file = sprintf_dup("%s/%s", work_dir, "base.dtb");
+        if (run_cmd("dtc -I fs -O dtb -o '%s' /proc/device-tree 1>/dev/null 2>&1",
+                    overlay_file) != 0)
+           return error("Failed to read active DTB");
+    }
+    else if ((len > 0) && (strcmp(overlay + len, ".dtbo") == 0))
+    {
+        const char *p;
+        overlay_file = overlay;
+        p = strrchr(overlay, '/');
+        if (p)
+        {
+            overlay = p + 1;
+            len = strlen(overlay) - 5;
+        }
+
+        overlay = sprintf_dup("%.*s", len, overlay);
+    }
+    else
+    {
+        const char *remapped = dtoverlay_remap_overlay(overlay);
+        int name_len;
+        if (!remapped)
+            return error("Failed to load '%s'", overlay);
+        if (strcmp(overlay, remapped))
+            dtoverlay_debug("mapped overlay '%s' to '%s'", overlay, remapped);
+        overlay = remapped;
+        name_len = strcspn(overlay, ",");
+        if (overlay[name_len])
+            overrides = overlay + name_len + 1;
+        overlay = sprintf_dup("%.*s", name_len, overlay);
+        overlay_file = sprintf_dup("%s/%s.dtbo", overlay_src_dir, overlay);
+    }
+
+    if (dry_run)
+        overlay_name = "dry_run";
+    else
+        overlay_name = sprintf_dup("%d_%s", state->count, overlay);
+    dtoverlay_debug("loading file '%s'", overlay_file);
+    overlay_dtb = dtoverlay_load_dtb(overlay_file, DTOVERLAY_PADDING(4096));
+    if (!overlay_dtb)
+        return error("Failed to read '%s'", overlay_file);
+
+    if (is_dtparam)
+    {
+        base_dtb = overlay_dtb;
+        string_vec_init(&used_props);
+    }
+
+    /* Apply any parameters that came from the overlay map */
+    while (overrides && *overrides)
+    {
+        int override_len = strcspn(overrides, ",");
+        char *override = strndup(overrides, override_len);
+        if (!override)
+            return error("Out of memory applying parameter");
+        err = apply_parameter(overlay_dtb, override, is_dtparam,
+                              &used_props, &param_string);
+        free(override);
+        if (err)
+            return err;
+        overrides += override_len + 1;
+    }
+
+    /* Then any supplied on the commad line */
+    for (i = 0; i < argc; i++)
+    {
+        err = apply_parameter(overlay_dtb, argv[i], is_dtparam,
+                              &used_props, &param_string);
+        if (err)
+            return err;
+    }
+
+    /* Apply any intra-overlay fragments, filtering the symbols */
+    err = dtoverlay_merge_overlay(NULL, overlay_dtb);
+    if (err != 0)
+        return error("Failed to apply intra-overlay fragments");
+
+    if (is_dtparam)
+    {
+        /* Build an overlay DTB */
+        overlay_dtb = dtoverlay_create_dtb(2048 + 256 * used_props.num_strings);
+
+        for (i = 0; i < used_props.num_strings; i++)
+        {
+            int phandle, node_off, prop_len;
+            const char *str, *prop_name;
+            const void *prop_data;
+
+            str = used_props.strings[i];
+            sscanf(str, "%8x", &phandle);
+            prop_name = str + 8;
+            node_off = dtoverlay_find_phandle(base_dtb, phandle);
+
+            prop_data = dtoverlay_get_property(base_dtb, node_off,
+                                               prop_name, &prop_len);
+            err = dtoverlay_create_prop_fragment(overlay_dtb, i, phandle,
+                                   prop_name, prop_data, prop_len);
+        }
+
+        dtoverlay_free_dtb(base_dtb);
+    }
+
+    if (param_string)
+        dtoverlay_dtb_set_trailer(overlay_dtb, param_string,
+                                  strlen(param_string) + 1);
+
+    /* Create a filename with the sequence number */
+    overlay_file = sprintf_dup("%s/%s.dtbo", work_dir, overlay_name);
+
+    /* then write the overlay to the file */
+    dtoverlay_pack_dtb(overlay_dtb);
+    dtoverlay_save_dtb(overlay_dtb, overlay_file);
+    dtoverlay_free_dtb(overlay_dtb);
+
+    if (!dry_run && !apply_overlay(overlay_file, overlay_name))
+    {
+        if (error_file)
+        {
+            rename(overlay_file, error_file);
+            free_string(error_file);
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+static int dtoverlay_remove(STATE_T *state, const char *overlay, int and_later)
+{
+    const char *overlay_dir;
+    const char *dir_name = NULL;
+    char *end;
+    int overlay_len;
+    int count = state->count;
+    int rmpos;
+    int i;
+
+    if (chdir(work_dir) != 0)
+        fatal_error("Failed to chdir to '%s'", work_dir);
+
+    if (overlay)
+    {
+        overlay_len = strlen(overlay);
+
+        rmpos = strtoul(overlay, &end, 10);
+        if (end && (*end == '\0'))
+        {
+            if (rmpos >= count)
+                return error("Overlay index (%d) too large", rmpos);
+            dir_name = state->namelist[rmpos]->d_name;
+        }
+        /* Locate the most recent reference to the overlay */
+        else for (rmpos = count - 1; rmpos >= 0; rmpos--)
+        {
+            const char *left, *right;
+            dir_name = state->namelist[rmpos]->d_name;
+            left = strchr(dir_name, '_');
+            if (!left)
+                return error("Internal error");
+            left++;
+            right = strchr(left, '.');
+            if (!right)
+                return error("Internal error");
+            if (((right - left) == overlay_len) &&
+                (memcmp(overlay, left, overlay_len) == 0))
+                break;
+            dir_name = NULL;
+        }
+
+        if (rmpos < 0)
+            return error("Overlay '%s' is not loaded", overlay);
+    }
+    else
+    {
+        if (!count)
+            return error("No overlays loaded");
+        rmpos = and_later ? 0 : (count - 1);
+        dir_name = state->namelist[rmpos]->d_name;
+    }
+
+    if (rmpos < count)
+    {
+        /* Unload it and all subsequent overlays in reverse order */
+        for (i = count - 1; i >= rmpos; i--)
+        {
+            const char *left, *right;
+            left = state->namelist[i]->d_name;
+            right = strrchr(left, '.');
+            if (!right)
+                return error("Internal error");
+
+            overlay_dir = sprintf_dup("%s/%.*s", dt_overlays_dir,
+                                      right - left, left);
+            if (rmdir(overlay_dir) != 0)
+                return error("Failed to remove directory '%s'", overlay_dir);
+
+            free_string(overlay_dir);
+        }
+
+        /* Replay the sequence, deleting files for the specified overlay,
+           and renumbering and reloading all other overlays. */
+        for (i = rmpos, state->count = rmpos; i < count; i++)
+        {
+            const char *left, *right;
+            const char *filename = state->namelist[i]->d_name;
+
+            left = strchr(filename, '_');
+            if (!left)
+                return error("Internal error");
+            left++;
+            right = strchr(left, '.');
+            if (!right)
+                return error("Internal error");
+
+            if (and_later || (i == rmpos))
+            {
+                /* This one is being deleted */
+                unlink(filename);
+            }
+            else
+            {
+                /* Keep this one - renumber and reload */
+                int len = right - left;
+                char *new_name = sprintf_dup("%d_%.*s", state->count,
+                                             len, left);
+                char *new_file = sprintf_dup("%s.dtbo", new_name);
+                int ret = 0;
+
+                if ((len == 7) && (memcmp(left, "dtparam", 7) == 0))
+                {
+                    /* Regenerate the overlay in case multiple overlays target
+                       different parts of the same property. */
+
+                    DTBLOB_T *dtb;
+                    char *params;
+                    const char **paramv;
+                    int paramc;
+                    int j;
+                    char *p;
+
+                    /* Extract the parameters */
+                    dtb = dtoverlay_load_dtb(filename, 0);
+                    unlink(filename);
+
+                    if (!dtb)
+                    {
+                        error("Failed to re-apply dtparam");
+                        continue;
+                    }
+
+                    params = (char *)dtoverlay_dtb_trailer(dtb);
+                    if (!params)
+                    {
+                        error("Failed to re-apply dtparam");
+                        dtoverlay_free_dtb(dtb);
+                        continue;
+                    }
+
+                    /* Count and NUL-separate the params */
+                    p = params;
+                    paramc = 0;
+                    while (*p)
+                    {
+                        int paramlen;
+                        *(p++) = '\0';
+                        paramlen = strcspn(p, " ");
+                        paramc++;
+                        p += paramlen;
+                    }
+
+                    paramv = malloc((paramc + 1) * sizeof(const char *));
+                    if (!paramv)
+                    {
+                        error("out of memory re-applying dtparam");
+                        dtoverlay_free_dtb(dtb);
+                        continue;
+                    }
+
+                    for (j = 0, p = params + 1; j < paramc; j++)
+                    {
+                        paramv[j] = p;
+                        p += strlen(p) + 1;
+                    }
+                    paramv[j] = NULL;
+
+                    /* Create the new overlay */
+                    ret = dtoverlay_add(state, "dtparam", paramc, paramv);
+                    free(paramv);
+                    dtoverlay_free_dtb(dtb);
+                }
+                else
+                {
+                    rename(filename, new_file);
+                    ret = !apply_overlay(new_file, new_name);
+                }
+                if (ret != 0)
+                {
+                    error("Failed to re-apply dtparam");
+                    continue;
+                }
+                state->count++;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int dtoverlay_list(STATE_T *state)
+{
+    if (state->count == 0)
+    {
+        printf("No overlays loaded\n");
+    }
+    else
+    {
+        int i;
+        printf("Overlays (in load order):\n");
+        for (i = 0; i < state->count; i++)
+        {
+            const char *name, *left, *right;
+            const char *saved_overlay;
+            DTBLOB_T *dtb;
+            name = state->namelist[i]->d_name;
+            left = strchr(name, '_');
+            if (!left)
+                return error("Internal error");
+            left++;
+            right = strchr(left, '.');
+            if (!right)
+                return error("Internal error");
+
+            saved_overlay = sprintf_dup("%s/%s", work_dir, name);
+            dtb = dtoverlay_load_dtb(saved_overlay, 0);
+
+            if (dtoverlay_dtb_trailer(dtb))
+                printf("%d:  %.*s %.*s\n", i, (int)(right - left), left,
+                       dtoverlay_dtb_trailer_len(dtb),
+                       (char *)dtoverlay_dtb_trailer(dtb));
+            else
+                printf("%d:  %.*s\n", i, (int)(right - left), left);
+
+            dtoverlay_free_dtb(dtb);
+        }
+    }
+
+    return 0;
+}
+
+static int dtoverlay_list_all(STATE_T *state)
+{
+    int i;
+    DIR *dh;
+    struct dirent *de;
+    STRING_VEC_T strings;
+
+    string_vec_init(&strings);
+
+    /* Enumerate .dtbo files in the /boot/overlays directory */
+    dh = opendir(overlay_src_dir);
+    while ((de = readdir(dh)) != NULL)
+    {
+        int len = strlen(de->d_name) - 5;
+        if ((len >= 0) && strcmp(de->d_name + len, ".dtbo") == 0)
+        {
+            char *str = string_vec_add(&strings, de->d_name, len + 2);
+            str[len] = '\0';
+            str[len + 1] = ' ';
+        }
+    }
+    closedir(dh);
+
+    /* Merge in active overlays, marking them */
+    for (i = 0; i < state->count; i++)
+    {
+        const char *left, *right;
+        char *str;
+        int len, idx;
+
+        left = strchr(state->namelist[i]->d_name, '_');
+        if (!left)
+            return error("Internal error");
+        left++;
+        right = strchr(left, '.');
+        if (!right)
+            return error("Internal error");
+
+        len = right - left;
+        if ((len == 7) && (memcmp(left, "dtparam", 7) == 0))
+            continue;
+        idx = string_vec_find(&strings, left, len);
+        if (idx >= 0)
+        {
+            str = strings.strings[idx];
+            len = strlen(str);
+        }
+        else
+        {
+            str = string_vec_add(&strings, left, len + 2);
+            str[len] = '\0';
+        }
+        str[len + 1] = '*';
+    }
+
+    if (strings.num_strings == 0)
+    {
+        printf("No overlays found\n");
+    }
+    else
+    {
+        /* Sort */
+        string_vec_sort(&strings);
+
+        /* Display */
+        printf("All overlays (* = loaded):\n");
+
+        for (i = 0; i < strings.num_strings; i++)
+        {
+            const char *str = strings.strings[i];
+            printf("%c %s\n", str[strlen(str)+1], str);
+        }
+    }
+
+    string_vec_uninit(&strings);
+
+    return 0;
+}
+
+static void usage(void)
+{
+    printf("Usage:\n");
+    if (strcmp(cmd_name, "dtparam") == 0)
+    {
+        printf("  %s                Display help on all parameters\n", cmd_name);
+        printf("  %s <param>=<val>...\n", cmd_name);
+        printf("  %*s                Add an overlay (with parameters)\n", (int)strlen(cmd_name), "");
+        printf("  %s -D             Dry-run (prepare overlay, but don't apply -\n",
+               cmd_name);
+        printf("  %*s                save it as dry-run.dtbo)\n", (int)strlen(cmd_name), "");
+        printf("  %s -r [<idx>]     Remove an overlay (by index, or the last)\n", cmd_name);
+        printf("  %s -R [<idx>]     Remove from an overlay (by index, or all)\n",
+               cmd_name);
+        printf("  %s -l             List active overlays/dtparams\n", cmd_name);
+        printf("  %s -a             List all overlays/dtparams (marking the active)\n", cmd_name);
+        printf("  %s -h             Show this usage message\n", cmd_name);
+        printf("  %s -h <param>...  Display help on the listed parameters\n", cmd_name);
+    }
+    else
+    {
+        printf("  %s <overlay> [<param>=<val>...]\n", cmd_name);
+        printf("  %*s                Add an overlay (with parameters)\n", (int)strlen(cmd_name), "");
+        printf("  %s -D             Dry-run (prepare overlay, but don't apply -\n",
+               cmd_name);
+        printf("  %*s                save it as dry-run.dtbo)\n", (int)strlen(cmd_name), "");
+        printf("  %s -r [<overlay>] Remove an overlay (by name, index or the last)\n", cmd_name);
+        printf("  %s -R [<overlay>] Remove from an overlay (by name, index or all)\n",
+               cmd_name);
+        printf("  %s -l             List active overlays/params\n", cmd_name);
+        printf("  %s -a             List all overlays (marking the active)\n", cmd_name);
+        printf("  %s -h             Show this usage message\n", cmd_name);
+        printf("  %s -h <overlay>   Display help on an overlay\n", cmd_name);
+        printf("  %s -h <overlay> <param>..  Or its parameters\n", cmd_name);
+        printf("    where <overlay> is the name of an overlay or 'dtparam' for dtparams\n");
+    }
+    printf("Options applicable to most variants:\n");
+    printf("    -d <dir>        Specify an alternate location for the overlays\n");
+    printf("                    (defaults to /boot/overlays or /flash/overlays)\n");
+    printf("    -p <string>     Force a compatible string for the platform\n");
+    printf("    -v              Verbose operation\n");
+    printf("\n");
+    printf("Adding or removing overlays and parameters requires root privileges.\n");
+
+    exit(1);
+}
+
+static void root_check(void)
+{
+    if (getuid() != 0)
+        fatal_error("Must be run as root - try 'sudo %s ...'", cmd_name);
+}
+
+static void overlay_help(const char *overlay, const char **params)
+{
+    OVERLAY_HELP_STATE_T *state;
+    const char *readme_path = sprintf_dup("%s/%s", overlay_src_dir,
+                                          README_FILE);
+
+    state = overlay_help_open(readme_path);
+    free_string(readme_path);
+
+    if (state)
+    {
+        if (strcmp(overlay, "dtparam") == 0)
+            overlay = "<The base DTB>";
+
+        if (overlay_help_find(state, overlay))
+        {
+            if (params && overlay_help_find_field(state, "Params"))
+            {
+                int in_param = 0;
+
+                while (1)
+                {
+                    const char *line = overlay_help_field_data(state);
+                    if (!line)
+                        break;
+                    if (line[0] == '\0')
+                        continue;
+                    if (line[0] != ' ')
+                    {
+                        /* This is a parameter name */
+                        size_t param_len = strcspn(line, " ");
+                        const char **p = params;
+                        const char **q = p;
+                        in_param = 0;
+                        while (*p)
+                        {
+                            if ((param_len == strlen(*p)) &&
+                                (memcmp(line, *p, param_len) == 0))
+                                in_param = 1;
+                            else
+                                *(q++) = *p;
+                            p++;
+                        }
+                        *(q++) = 0;
+                    }
+                    if (in_param)
+                        printf("%s\n", line);
+                }
+                /* This only shows the first unknown parameter, but
+                 * that is enough. */
+                if (*params)
+                    fatal_error("Unknown parameter '%s'", *params);
+            }
+            else
+            {
+                printf("Name:   %s\n\n", overlay);
+                overlay_help_print_field(state, "Info", "Info:", 8, 0);
+                overlay_help_print_field(state, "Load", "Usage:", 8, 0);
+                overlay_help_print_field(state, "Params", "Params:", 8, 0);
+            }
+        }
+        else
+        {
+            fatal_error("No help found for overlay '%s'", overlay);
+        }
+        overlay_help_close(state);
+    }
+    else
+    {
+        fatal_error("Help file not found");
+    }
+}
+
+static int apply_overlay(const char *overlay_file, const char *overlay)
+{
+    const char *overlay_dir = sprintf_dup("%s/%s", dt_overlays_dir, overlay);
+    int ret = 0;
+    if (dir_exists(overlay_dir))
+    {
+        error("Overlay '%s' is already loaded", overlay);
+    }
+    else if (mkdir(overlay_dir, DIR_MODE) == 0)
+    {
+        DTBLOB_T *dtb = dtoverlay_load_dtb(overlay_file, 0);
+        if (!dtb)
+        {
+            error("Failed to apply overlay '%s' (load)", overlay);
+        }
+        else
+        {
+            const char *dest_file = sprintf_dup("%s/dtbo", overlay_dir);
+
+            /* then write the overlay to the file */
+            if (dtoverlay_save_dtb(dtb, dest_file) != 0)
+                error("Failed to apply overlay '%s' (save)", overlay);
+            else if (!overlay_applied(overlay_dir))
+                error("Failed to apply overlay '%s' (kernel)", overlay);
+            else
+                ret = 1;
+
+            free_string(dest_file);
+            dtoverlay_free_dtb(dtb);
+        }
+
+        if (!ret)
+            rmdir(overlay_dir);
+    }
+    else
+    {
+        error("Failed to create overlay directory");
+    }
+
+    return ret;
+}
+
+static int overlay_applied(const char *overlay_dir)
+{
+    char status[7] = { '\0' };
+    const char *status_path = sprintf_dup("%s/status", overlay_dir);
+    FILE *fp = fopen(status_path, "r");
+    int bytes = 0;
+    if (fp)
+    {
+        bytes = fread(status, 1, sizeof(status), fp);
+        fclose(fp);
+    }
+    free_string(status_path);
+    return (bytes == sizeof(status)) &&
+        (memcmp(status, "applied", sizeof(status)) == 0);
+}
+
+int seq_filter(const struct dirent *de)
+{
+    int num;
+    return (sscanf(de->d_name, "%d_", &num) == 1);
+}
+
+int seq_compare(const struct dirent **de1, const struct dirent **de2)
+{
+    int num1 = atoi((*de1)->d_name);
+    int num2 = atoi((*de2)->d_name);
+    if (num1 < num2)
+        return -1;
+    else if (num1 == num2)
+        return 0;
+    else
+        return 1;
+}
+
+static STATE_T *read_state(const char *dir)
+{
+    STATE_T *state = malloc(sizeof(STATE_T));
+    int i;
+
+    if (state)
+    {
+        state->count = scandir(dir, &state->namelist, seq_filter, seq_compare);
+
+        for (i = 0; i < state->count; i++)
+        {
+            int num = atoi(state->namelist[i]->d_name);
+            if (i != num)
+                error("Overlay sequence error");
+        }
+    }
+    return state;
+}
+
+static void free_state(STATE_T *state)
+{
+    int i;
+    for (i = 0; i < state->count; i++)
+    {
+        free(state->namelist[i]);
+    }
+    free(state->namelist);
+    free(state);
+}

--- a/dtmerge/dtparam.1
+++ b/dtmerge/dtparam.1
@@ -1,0 +1,66 @@
+.TH DTPARAM 1
+.
+.SH NAME
+dtparam \- mainpulate parameters of the base device-tree
+.
+.
+.SH SYNOPSIS
+.SY dtparam
+.RI [ param=val \|.\|.\|.]
+.YS
+.
+.SY dtparam
+.B \-h
+.RI [ param ]
+.YS
+.
+.
+.SH DESCRIPTION
+.B dtparam
+is a command line utility for manipulating the base device-tree's parameters.
+For example, it can be used to enable the SPI or I2C interfaces at runtime
+without rebooting.
+If
+.B dtparam
+is run without any argument, it prints the names of all base device-tree
+parameters and their description.
+.
+.
+.SH OPTIONS
+.
+.TP
+.BR \-h " [\fIparam\fR]"
+If given without
+.I param
+displays help on the application overall. If
+.I param
+is specified, prints help about that parameter in the base device-tree.
+.
+.
+.SH EXAMPLES
+.
+.TP
+.B sudo dtparam spi=on
+Enable the SPI interface on the GPIO header. Note that root privileges are
+usually required for manipulating the base device-tree (hence, sudo in the
+example).
+.
+.TP
+.B dtparam -h spi
+Print help about the "spi" parameter.
+.
+.TP
+.B sudo dtparam audio=off
+Disable the audio output.
+.
+.
+.SH SEE ALSO
+.BR dtoverlay (1),
+.BR dtmerge (1),
+.B [DTREE]
+.
+.
+.SH REFERENCES
+.TP
+.B [DTREE]
+https://www.raspberrypi.org/documentation/configuration/device-tree.md

--- a/dtmerge/utils.c
+++ b/dtmerge/utils.c
@@ -1,0 +1,490 @@
+/*
+Copyright (c) 2016 Raspberry Pi (Trading) Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+#include "utils.h"
+
+#define OVERLAY_HELP_INDENT 8
+
+int opt_verbose;
+int opt_dry_run;
+static STRING_T *allocated_strings;
+
+struct overlay_help_state_struct
+{
+    FILE *fp;
+    long rec_pos;
+    int line_len;
+    int line_pos;
+    int blank_count;
+    int end_of_field;
+    char line_buf[82];
+};
+
+static int overlay_help_get_line(OVERLAY_HELP_STATE_T *state);
+
+OVERLAY_HELP_STATE_T *overlay_help_open(const char *helpfile)
+{
+    OVERLAY_HELP_STATE_T *state = NULL;
+    FILE *fp = fopen(helpfile, "r");
+    if (fp)
+    {
+        state = calloc(1, sizeof(OVERLAY_HELP_STATE_T));
+        if (!state)
+                fatal_error("Out of memory");
+        state->fp = fp;
+        state->line_pos = -1;
+        state->rec_pos = -1;
+    }
+
+    return state;
+}
+
+void overlay_help_close(OVERLAY_HELP_STATE_T *state)
+{
+    fclose(state->fp);
+    free(state);
+}
+
+int overlay_help_find(OVERLAY_HELP_STATE_T *state, const char *name)
+{
+    state->line_pos = -1;
+    state->rec_pos = -1;
+    state->blank_count = 0;
+
+    fseek(state->fp, 0, SEEK_SET);
+
+    while (overlay_help_find_field(state, "Name"))
+    {
+        const char *overlay = overlay_help_field_data(state);
+        if (overlay && (strcmp(overlay, name) == 0))
+        {
+            state->rec_pos = (long)ftell(state->fp);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int overlay_help_find_field(OVERLAY_HELP_STATE_T *state, const char *field)
+{
+    int field_len = strlen(field);
+    int found = 0;
+
+    if (state->rec_pos >= 0)
+        fseek(state->fp, state->rec_pos, SEEK_SET);
+
+    while (!found)
+    {
+        int line_len = overlay_help_get_line(state);
+        if (line_len < 0)
+            break;
+
+        /* Check for the "<field>:" prefix */
+        if ((line_len >= (field_len + 1)) &&
+            (state->line_buf[field_len] == ':') &&
+            (memcmp(state->line_buf, field, field_len) == 0))
+        {
+            /* Found it
+               If this initial line has no content then skip it */
+            if (line_len > OVERLAY_HELP_INDENT)
+                state->line_pos = OVERLAY_HELP_INDENT;
+            else
+                state->line_pos = -1;
+            state->end_of_field = 0;
+            found = 1;
+        }
+        else
+        {
+            state->line_pos = -1;
+        }
+    }
+
+    return found;
+}
+
+const char *overlay_help_field_data(OVERLAY_HELP_STATE_T *state)
+{
+    int line_len, pos;
+
+    if (state->end_of_field)
+        return NULL;
+
+    line_len = state->line_len;
+
+    if ((state->line_pos < 0) ||
+        (state->line_pos >= line_len))
+    {
+        line_len = overlay_help_get_line(state);
+
+        /* Fields end at the start of the next field or the end of the record */
+        if ((line_len < 0) || (state->line_buf[0] != ' '))
+        {
+            state->end_of_field = 1;
+            return NULL;
+        }
+
+        if (line_len == 0)
+            return "";
+    }
+
+    /* Return field data starting at OVERLAY_HELP_INDENT, if there is any */
+    pos = line_len;
+    if (pos > OVERLAY_HELP_INDENT)
+        pos = OVERLAY_HELP_INDENT;
+
+    state->line_pos = -1;
+    return &state->line_buf[pos];
+}
+
+void overlay_help_print_field(OVERLAY_HELP_STATE_T *state,
+                              const char *field, const char *label,
+                              int indent, int strip_blanks)
+{
+    if (!overlay_help_find_field(state, field))
+        return;
+
+    while (1)
+    {
+	const char *line = overlay_help_field_data(state);
+	if (!line)
+	    break;
+
+	if (label)
+	{
+	    int spaces = indent - strlen(label);
+	    if (spaces < 0)
+		spaces = 0;
+
+	    printf("%s%*s%s\n", label, spaces, "", line);
+	    label = NULL;
+	}
+	else if (line[0])
+	{
+	    printf("%*s%s\n", indent, "", line);
+	}
+	else if (!strip_blanks)
+	{
+	    printf("\n");
+	}
+    }
+
+    if (!strip_blanks)
+	printf("\n");
+}
+
+/* Returns the length of the line, or -1 on end of file or record */
+static int overlay_help_get_line(OVERLAY_HELP_STATE_T *state)
+{
+    int line_len;
+
+    if (state->line_pos >= 0)
+	return state->line_len;
+
+get_next_line:
+    state->line_buf[sizeof(state->line_buf) - 1] = ' ';
+    line_len = -1;
+    if (fgets(state->line_buf, sizeof(state->line_buf), state->fp))
+    {
+	// Check for overflow
+
+	// Strip the newline
+	line_len = strlen(state->line_buf);
+	if (line_len && (state->line_buf[line_len - 1] == '\n'))
+	{
+	    line_len--;
+	    state->line_buf[line_len] = '\0';
+	}
+    }
+
+    if (state->rec_pos >= 0)
+    {
+	if (line_len == 0)
+	{
+	    state->blank_count++;
+	    if (state->blank_count >= 2)
+		return -1;
+	    state->line_pos = 0;
+	    goto get_next_line;
+	}
+	else if (state->blank_count)
+	{
+	    /* Return a single blank line now - the non-empty line will be
+	       returned next time */
+	    state->blank_count = 0;
+	    return 0;
+	}
+    }
+
+    state->line_len = line_len;
+    state->line_pos = (line_len >= 0) ? 0 : -1;
+    return line_len;
+}
+
+int run_cmd(const char *fmt, ...)
+{
+    va_list ap;
+    char *cmd;
+    int ret;
+    va_start(ap, fmt);
+    cmd = vsprintf_dup(fmt, ap);
+    va_end(ap);
+
+    if (opt_dry_run || opt_verbose)
+	fprintf(stderr, "run_cmd: %s\n", cmd);
+
+    ret = opt_dry_run ? 0 : system(cmd);
+
+    free_string(cmd);
+
+    return ret;
+}
+
+
+/* Not thread safe */
+void free_string(const char *string)
+{
+    STRING_T *str;
+
+    if (!string)
+	return;
+
+    str = (STRING_T *)(string - sizeof(STRING_T));
+    if (str == allocated_strings)
+    {
+	allocated_strings = str->next;
+	if (allocated_strings == str)
+	    allocated_strings = NULL;
+    }
+    str->prev->next = str->next;
+    str->next->prev = str->prev;
+    free(str);
+}
+
+/* Not thread safe */
+void free_strings(void)
+{
+    if (allocated_strings)
+    {
+	STRING_T *str = allocated_strings;
+	do
+	{
+	    STRING_T *t = str;
+	    str = t->next;
+	    free(t);
+	} while (str != allocated_strings);
+	allocated_strings = NULL;
+    }
+}
+
+/* Not thread safe */
+char *sprintf_dup(const char *fmt, ...)
+{
+    va_list ap;
+    char *str;
+    va_start(ap, fmt);
+    str = vsprintf_dup(fmt, ap);
+    va_end(ap);
+    return str;
+}
+
+/* Not thread safe */
+char *vsprintf_dup(const char *fmt, va_list ap)
+{
+    char scratch[512];
+    size_t len;
+    STRING_T *str;
+    len = vsnprintf(scratch, sizeof(scratch), fmt, ap) + 1;
+
+    if (len > sizeof(scratch))
+	fatal_error("Maximum string length exceeded");
+
+    str = malloc(sizeof(STRING_T) + len);
+    if (!str)
+	fatal_error("Out of memory");
+
+    memcpy(str->data, scratch, len);
+    if (allocated_strings)
+    {
+	str->next = allocated_strings;
+	str->prev = allocated_strings->prev;
+	str->next->prev = str;
+	str->prev->next = str;
+    }
+    else
+    {
+	str->next = str;
+	str->prev = str;
+	allocated_strings = str;
+    }
+
+    return str->data;
+}
+
+int dir_exists(const char *dirname)
+{
+    struct stat finfo;
+    return (stat(dirname, &finfo) == 0) && S_ISDIR(finfo.st_mode);
+}
+
+int file_exists(const char *dirname)
+{
+    struct stat finfo;
+    return (stat(dirname, &finfo) == 0) && S_ISREG(finfo.st_mode);
+}
+
+void string_vec_init(STRING_VEC_T *vec)
+{
+    vec->num_strings = 0;
+    vec->max_strings = 0;
+    vec->strings = NULL;
+}
+
+char *string_vec_add(STRING_VEC_T *vec, const char *str, int len)
+{
+    char *copy;
+    if (vec->num_strings == vec->max_strings)
+    {
+	if (vec->max_strings)
+	    vec->max_strings *= 2;
+	else
+	    vec->max_strings = 16;
+	vec->strings = realloc(vec->strings, vec->max_strings * sizeof(const char *));
+	if (!vec->strings)
+	    fatal_error("Out of memory");
+    }
+
+    if (len)
+    {
+	copy = malloc(len + 1);
+	strncpy(copy, str, len);
+	copy[len] = '\0';
+    }
+    else
+       copy = strdup(str);
+
+    if (!copy)
+	fatal_error("Out of memory");
+
+    vec->strings[vec->num_strings++] = copy;
+
+    return copy;
+}
+
+int string_vec_find(STRING_VEC_T *vec, const char *str, int len)
+{
+    int i;
+
+    for (i = 0; i < vec->num_strings; i++)
+    {
+	if (len)
+	{
+	    if ((strncmp(vec->strings[i], str, len) == 0) &&
+		(vec->strings[i][len] == '\0'))
+		return i;
+	}
+	else if (strcmp(vec->strings[i], str) == 0)
+	    return i;
+    }
+
+    return -1;
+}
+
+int string_vec_compare(const void *a, const void *b)
+{
+    return strcmp(*(const char **)a, *(const char **)b);
+}
+
+void string_vec_sort(STRING_VEC_T *vec)
+{
+    qsort(vec->strings, vec->num_strings, sizeof(char *), &string_vec_compare);
+}
+
+void string_vec_uninit(STRING_VEC_T *vec)
+{
+    int i;
+    for (i = 0; i < vec->num_strings; i++)
+	free(vec->strings[i]);
+    free(vec->strings);
+}
+
+int error(const char *fmt, ...)
+{
+    va_list ap;
+    fprintf(stderr, "* ");
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fprintf(stderr, "\n");
+    return 1;
+}
+
+void fatal_error(const char *fmt, ...)
+{
+    va_list ap;
+    fprintf(stderr, "* ");
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fprintf(stderr, "\n");
+    exit(1);
+}
+
+char *read_file_as_string(const char *path, int *plen)
+{
+    FILE *fp = fopen(path, "r");
+    char *string = NULL;
+    long len = 0;
+    if (fp)
+    {
+        long bytes_read;
+
+        fseek(fp, 0, SEEK_END);
+        len = ftell(fp);
+        fseek(fp, 0, SEEK_SET);
+        /* Ensure NUL-termination */
+        string = malloc(len + 1);
+        if (!string)
+            fatal_error("Out of memory", path);
+        string[len] = 0;
+        bytes_read = fread(string, 1, len, fp);
+        if (bytes_read != len)
+            fatal_error("Failed to read file '%s'", path);
+        fclose(fp);
+    }
+    if (plen)
+        *plen = (int)len;
+    return string;
+}

--- a/dtmerge/utils.h
+++ b/dtmerge/utils.h
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2016 Raspberry Pi (Trading) Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef UTILS_H
+#define UTILS_H
+
+typedef struct string_struct
+{
+    struct string_struct *prev;
+    struct string_struct *next;
+    char data[0];
+} STRING_T;
+
+typedef struct string_vec_struct
+{
+    int num_strings;
+    int max_strings;
+    char **strings;
+} STRING_VEC_T;
+
+typedef struct overlay_help_state_struct OVERLAY_HELP_STATE_T;
+
+extern int opt_verbose;
+extern int opt_dry_run;
+
+OVERLAY_HELP_STATE_T *overlay_help_open(const char *helpfile);
+void overlay_help_close(OVERLAY_HELP_STATE_T *state);
+int overlay_help_find(OVERLAY_HELP_STATE_T *state, const char *name);
+int overlay_help_find_field(OVERLAY_HELP_STATE_T *state, const char *field);
+const char *overlay_help_field_data(OVERLAY_HELP_STATE_T *state);
+void overlay_help_print_field(OVERLAY_HELP_STATE_T *state,
+			      const char *field, const char *label,
+			      int indent, int strip_blanks);
+
+int run_cmd(const char *fmt, ...);
+void free_string(const char *string); /* Not thread safe */
+void free_strings(void); /* Not thread safe */
+char *sprintf_dup(const char *fmt, ...); /* Not thread safe */
+char *vsprintf_dup(const char *fmt, va_list ap); /* Not thread safe */
+int dir_exists(const char *dirname);
+int file_exists(const char *dirname);
+void string_vec_init(STRING_VEC_T *vec);
+char *string_vec_add(STRING_VEC_T *vec, const char *str, int len);
+int string_vec_find(STRING_VEC_T *vec, const char *str, int len);
+void string_vec_sort(STRING_VEC_T *vec);
+void string_vec_uninit(STRING_VEC_T *vec);
+int error(const char *fmt, ...);
+void fatal_error(const char *fmt, ...);
+char *read_file_as_string(const char *path, int *plen);
+
+#endif


### PR DESCRIPTION
These utilities previously lived in the soon-to-be-abandoned userland repo. While adding them here the shared-library status of libdtovl has been dropped for simplicity.