### PR TITLE
raspinfo: remove bashisms to run on sh

### DIFF
--- a/raspinfo/raspinfo
+++ b/raspinfo/raspinfo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Some of the regex's used in sed
 # Catch basic IP6 address   "s/\([0-9a-fA-F]\{1,4\}:\)\{7,7\}[0-9a-fA-F]\{1,4\}/y.y.y.y.y.y.y.y/g"
@@ -11,7 +11,7 @@ display_info_drm() {
    # If running X then can use xrandr, otherwise
    # dump the /sys/class entries for the displays
    if command -v xrandr > /dev/null &&
-      DISPLAY=${DISPLAY:-:0} xrandr --listmonitors &>/dev/null;
+      DISPLAY=${DISPLAY:-:0} xrandr --listmonitors >/dev/null 2>&1;
    then
       echo "Running (F)KMS and X"
       echo
@@ -77,7 +77,7 @@ display_info_drm() {
       cardfound=1
       fi
    done
-   if [ "$cardfound" == "0" ];
+   if [ "$cardfound" = "0" ];
    then
       echo "kms state not found"
    fi
@@ -137,7 +137,11 @@ OUT=raspinfo.txt
 
 rm -f $OUT
 
-exec > >(tee -ia $OUT)
+# avoid process substition bashism to generate logfile
+PIPE_PATH=$(mktemp -u)
+mkfifo $PIPE_PATH
+tee -ia $OUT < $PIPE_PATH &
+exec > $PIPE_PATH
 
 echo "System Information"
 echo "------------------"


### PR DESCRIPTION
may be useful to be able to run raspinfo on streamlined systems without bash dependency (ie: just busybox sh).