### PR TITLE
CMakeLists.txt: use min...max notation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.27)
 
 project(utils)
 

--- a/dtmerge/CMakeLists.txt
+++ b/dtmerge/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.27)
 
 include(GNUInstallDirs)
 

--- a/otpset/CMakeLists.txt
+++ b/otpset/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.27)
 
 include(GNUInstallDirs)
 

--- a/overlaycheck/CMakeLists.txt
+++ b/overlaycheck/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.27)
 
 include(GNUInstallDirs)
 

--- a/ovmerge/CMakeLists.txt
+++ b/ovmerge/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.27)
 
 include(GNUInstallDirs)
 

--- a/pinctrl/CMakeLists.txt
+++ b/pinctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.27)
 include(GNUInstallDirs)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")

--- a/raspinfo/CMakeLists.txt
+++ b/raspinfo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.27)
 
 include(GNUInstallDirs)
 

--- a/vcgencmd/CMakeLists.txt
+++ b/vcgencmd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.27)
 
 include(GNUInstallDirs)
 

--- a/vclog/CMakeLists.txt
+++ b/vclog/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.27)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")
 

--- a/vcmailbox/CMakeLists.txt
+++ b/vcmailbox/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.27)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Using this future proofs the build and surpresses a harmless but annoying warning:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.

-- The C compiler identification is GNU 12.1.0
-- The CXX compiler identification is GNU 12.1.0
...
```