### PR TITLE
eeptools: eepdump: init type before calling eepio_atom_start

### DIFF
--- a/eeptools/eepdump.c
+++ b/eeptools/eepdump.c
@@ -133,7 +133,7 @@ static int read_bin(const char *in, const char *outf)
 	for (i = 0; i < numatoms && !eepio_got_error(); i++)
 	{
 		unsigned int gpio_count;
-		enum atom_type_t type;
+		enum atom_type_t type = ATOM_INVALID_TYPE;
 		bool bank1 = false;
 		uint32_t dlen;
 


### PR DESCRIPTION
Compilation fails with GCC 13:
https://github.com/openwrt/openwrt/commit/e57eb9f28e7ba383796df8cae1b3ca39804f6326?w=1#commitcomment-137339982
```
FAILED: eeptools/eepdump
: && /home/cschuette/openwrt/snapshot/openwrt/staging_dir/toolchain-aarch64_cortex-a72_gcc-13.2.0_musl/bin/aarch64-openwrt-linux-musl-gcc -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -ffile-prefix-map=/home/cschuette/openwrt/snapshot/openwrt/build_dir/target-aarch64_cortex-a72_musl/bcm27xx-utils-2024-01-15=bcm27xx-utils-2024-01-15 -ffunction-sections -fdata-sections -flto=auto -fno-fat-lto-objects -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -Wall -Wextra -Werror -DNDEBUG -L/home/cschuette/openwrt/snapshot/openwrt/staging_dir/toolchain-aarch64_cortex-a72_gcc-13.2.0_musl/usr/lib -L/home/cschuette/openwrt/snapshot/openwrt/staging_dir/toolchain-aarch64_cortex-a72_gcc-13.2.0_musl/lib -fuse-ld=bfd -Wl,--gc-sections -flto=auto -fuse-linker-plugin -znow -zrelro eeptools/CMakeFiles/eepdump.dir/eepdump.c.o eeptools/CMakeFiles/eepdump.dir/eeplib.c.o -o eeptools/eepdump   && :
In function 'eepio_atom_start',
    inlined from 'read_bin' at eeptools/eepdump.c:140:8:
eeptools/eeplib.c:251:38: error: 'type' may be used uninitialized [-Werror=maybe-uninitialized]
  251 |                 eep_atom_header.type = *type;
      |                                      ^
eeptools/eepdump.c: In function 'read_bin':
eeptools/eepdump.c:136:34: note: 'type' was declared here
  136 |                 enum atom_type_t type;
      |                                  ^
```