### PR TITLE
build: Only enable -Werror for debug builds

### DIFF
--- a/dtmerge/CMakeLists.txt
+++ b/dtmerge/CMakeLists.txt
@@ -5,7 +5,7 @@ include(GNUInstallDirs)
 #set project name
 project(dtmerge)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+add_compile_options(-Wall -Wextra $<$<CONFIG:Debug>:-Werror>)
 
 if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)

--- a/eeptools/CMakeLists.txt
+++ b/eeptools/CMakeLists.txt
@@ -5,7 +5,7 @@ include(GNUInstallDirs)
 #set project name
 project(eeptools)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+add_compile_options(-Wall -Wextra $<$<CONFIG:Debug>:-Werror>)
 
 if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)

--- a/pinctrl/CMakeLists.txt
+++ b/pinctrl/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 include(GNUInstallDirs)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")
+add_compile_options(-Wall -Wextra $<$<CONFIG:Debug>:-Werror> -pedantic)
 
 #set project name
 project(pinctrl)

--- a/pinctrl/CMakeLists.txt
+++ b/pinctrl/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 include(GNUInstallDirs)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+add_compile_options(-Wall -Wextra $<$<CONFIG:Debug>:-Werror>)
 
 #set project name
 project(pinctrl)

--- a/piolib/CMakeLists.txt
+++ b/piolib/CMakeLists.txt
@@ -9,7 +9,7 @@ project(piolib)
 
 add_compile_definitions(LIBRARY_BUILD=1)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+add_compile_options(-Wall -Wextra $<$<CONFIG:Debug>:-Werror>)
 
 if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)

--- a/piolib/examples/CMakeLists.txt
+++ b/piolib/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ include(GNUInstallDirs)
 #set project name
 project(examples)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+add_compile_options(-Wall -Wextra $<$<CONFIG:Debug>:-Werror>)
 
 if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)

--- a/rpieepromab/CMakeLists.txt
+++ b/rpieepromab/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 include(GNUInstallDirs)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+add_compile_options(-Wall -Wextra $<$<CONFIG:Debug>:-Werror>)
 
 # Set project name and version
 project(rpieepromab VERSION 0.2.2)

--- a/rpifwcrypto/CMakeLists.txt
+++ b/rpifwcrypto/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 include(GNUInstallDirs)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+add_compile_options(-Wall -Wextra $<$<CONFIG:Debug>:-Werror>)
 
 # Set project name
 project(rpifwcrypto)

--- a/vclog/CMakeLists.txt
+++ b/vclog/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")
+add_compile_options(-Wall -Wextra $<$<CONFIG:Debug>:-Werror> -pedantic)
 
 #set project name
 project(vclog)


### PR DESCRIPTION
`-Werror` is very unhelpful for distributions and end users as newer compilers will raise warnings that the maintainers may not see. The warnings should get reported upstream, but they shouldn't block users from using the software.

Rather than drop the flag entirely, I have enabled it only for debug builds, e.g. `-DCMAKE_BUILD_TYPE=Debug`.