### PR TITLE
pinctrl: Speed up RP1 GPIO drive set

### DIFF
--- a/eeptools/eepmake.c
+++ b/eeptools/eepmake.c
@@ -614,7 +614,7 @@ static int read_text(const char *in)
 	if (has_gpio_bank1 && (!bank1_gpio_drive_set || !bank1_gpio_slew_set || !bank1_gpio_hysteresis_set))
 		printf("Warning: required fields missing in GPIO map of bank 1, using default values\n");
 
-	if (dt_blob.data && !isalnum(dt_blob.data[0]))
+	if (hat_format != EEP_VERSION_HATV1 && dt_blob.data && !isalnum(dt_blob.data[0]))
 		fatal_error("Only embed the name of the overlay");
 
 	printf("Done reading\n");

--- a/pinctrl/gpiochip_rp1.c
+++ b/pinctrl/gpiochip_rp1.c
@@ -194,13 +194,16 @@ static uint32_t rp1_gpio_sys_rio_sync_in_read(volatile uint32_t *base, int bank,
                            RP1_GPIO_SYS_RIO_REG_SYNC_IN_OFFSET);
 }
 
-
-static void rp1_gpio_sys_rio_out_write(volatile uint32_t *base, int bank,
-                                       int offset, uint32_t value)
+static void rp1_gpio_sys_rio_out_set(volatile uint32_t *base, int bank, int offset)
 {
-    UNUSED(offset);
     rp1_gpio_write32(base, gpio_state.sys_rio[bank],
-                     RP1_GPIO_SYS_RIO_REG_OUT_OFFSET, value);
+                     RP1_GPIO_SYS_RIO_REG_OUT_OFFSET + RP1_SET_OFFSET, 1U << offset);
+}
+
+static void rp1_gpio_sys_rio_out_clr(volatile uint32_t *base, int bank, int offset)
+{
+    rp1_gpio_write32(base, gpio_state.sys_rio[bank],
+                     RP1_GPIO_SYS_RIO_REG_OUT_OFFSET + RP1_CLR_OFFSET, 1U << offset);
 }
 
 static uint32_t rp1_gpio_sys_rio_oe_read(volatile uint32_t *base, int bank)
@@ -355,16 +358,13 @@ static int rp1_gpio_get_level(void *priv, unsigned gpio)
 static void rp1_gpio_set_drive(void *priv, unsigned gpio, GPIO_DRIVE_T drv)
 {
     volatile uint32_t *base = priv;
-    uint32_t reg;
     int bank, offset;
 
     rp1_gpio_get_bank(gpio, &bank, &offset);
-    reg = rp1_gpio_sys_rio_out_read(base, bank, offset);
     if (drv == DRIVE_HIGH)
-        reg |= (1U << offset);
+        rp1_gpio_sys_rio_out_set(base, bank, offset);
     else if (drv == DRIVE_LOW)
-        reg &= ~(1U << offset);
-    rp1_gpio_sys_rio_out_write(base, bank, offset, reg);
+        rp1_gpio_sys_rio_out_clr(base, bank, offset);
 }
 
 static void rp1_gpio_set_pull(void *priv, unsigned gpio, GPIO_PULL_T pull)


### PR DESCRIPTION
Use the atomic set/clr feature of RP1 to set the output drive on a GPIO, which makes it much faster.

See: https://github.com/raspberrypi/utils/issues/73