### PR TITLE
Correct help-text for pinctrl poll

### DIFF
--- a/pinctrl/pinctrl.c
+++ b/pinctrl/pinctrl.c
@@ -75,7 +75,7 @@ static void usage()
     printf("OR\n");
     printf("  %s [-p] [-v] [-e] set <GPIO> [options]\n", name);
     printf("OR\n");
-    printf("  %s [-p] [-v] poll [GPIO]\n", name);
+    printf("  %s [-p] [-v] poll <GPIO>\n", name);
     printf("OR\n");
     printf("  %s [-p] [-v] funcs [GPIO]\n", name);
     printf("OR\n");


### PR DESCRIPTION
GPIO argument is required, not optional