### PR TITLE
flush stdout on every level change

### DIFF
--- a/pinctrl/pinctrl.c
+++ b/pinctrl/pinctrl.c
@@ -307,6 +307,7 @@ static void do_gpio_poll(void)
                 printf("%2d: %s // %s\n", state->num, level ? "hi" : "lo", state->name);
                 state->level = level;
                 changed = 1;
+                fflush(stdout);
             }
         }
         if (!changed)


### PR DESCRIPTION
To be able to redirect stdout 'pinctrl' output in polling mode, a flush stdout after every level change is needed.
