### PR TITLE
vclog: fix compiler error with gcc-14.1

### DIFF
--- a/vclog/vclog.c
+++ b/vclog/vclog.c
@@ -194,6 +194,7 @@ int32_t main(int32_t argc, char *argv[])
             uint32_t payload_pos;
             uint32_t payload_len;
 
+            msg.size = 0;
             payload_pos = log_copy_wrap(log_buffer, log_size,
                                         read_pos, sizeof(msg), (char *)&msg);
             payload_len = msg.size - sizeof(msg_hdr_t);


### PR DESCRIPTION
Fixes:

./vclog/vclog.c:199:30: error: 'msg.size' may be used uninitialized [-Werror=maybe-uninitialized]
  199 |             payload_len = msg.size - sizeof(msg_hdr_t);
      |                           ~~~^~~~~
./vclog/vclog.c:193:23: note: 'msg' declared here
  193 |             msg_hdr_t msg;
      |                       ^~~