### PR TITLE
vclog: fix max realloc compiler error

### DIFF
--- a/vclog/vclog.c
+++ b/vclog/vclog.c
@@ -72,6 +72,7 @@ enum
 };
 
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #define ARRAY_SIZE(_a) (sizeof(_a)/sizeof(_a[0]))
 
 #define FBIODMACOPY _IOW('z', 0x22, struct fb_dmacopy)
@@ -207,7 +208,7 @@ int32_t main(int32_t argc, char *argv[])
             if (payload_len > payload_buffer_size)
             {
                 payload_buffer_size = MAX(payload_len, 100); // skip some churn
-                payload_buffer = realloc(payload_buffer, payload_buffer_size);
+                payload_buffer = realloc(payload_buffer, MIN(INT32_MAX, payload_buffer_size));
                 if (!payload_buffer)
                     die("Out of memory");
             }


### PR DESCRIPTION
- Fixes #87

./vclog/vclog.c:211:34: error: argument 2 value '4294967288' exceeds maximum object size 2147483647 [-Werror=alloc-size-larger-than=]
  211 |                 payload_buffer = realloc(payload_buffer, payload_buffer_size);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./vclog/vclog.c:17:
../../toolchain/armv7ve-libreelec-linux-gnueabihf/sysroot/usr/include/stdlib.h:683:14: note: in a call to allocation function 'realloc' declared here
  683 | extern void *realloc (void *__ptr, size_t __size)
      |              ^~~~~~~