### PR TITLE
 Wait 10ms per iteration in polling loop

### DIFF
--- a/pinctrl/pinctrl.c
+++ b/pinctrl/pinctrl.c
@@ -316,6 +316,7 @@ static void do_gpio_poll(void)
                 gettimeofday(&idle_start, NULL);
             idle_count++;
         }
+        usleep(10000); // wait 10ms per polling loop, prevent "pinctrl poll" taking 100% CPU resources from one core
     }
 }
 

--- a/pinctrl/pinctrl.c
+++ b/pinctrl/pinctrl.c
@@ -307,6 +307,7 @@ static void do_gpio_poll(void)
                 printf("%2d: %s // %s\n", state->num, level ? "hi" : "lo", state->name);
                 state->level = level;
                 changed = 1;
+                fflush(stdout);
             }
         }
         if (!changed)


### PR DESCRIPTION
prevent "pinctrl poll" taking 100% CPU resources from one core.
