### PR TITLE
Fix modern groff warnings in manpages

### DIFF
--- a/vcgencmd/vcgencmd.1
+++ b/vcgencmd/vcgencmd.1
@@ -1,3 +1,4 @@
+'\" t
 .TH VCGENCMD 1
 .
 .SH NAME

--- a/vcmailbox/raspirev.7
+++ b/vcmailbox/raspirev.7
@@ -1,3 +1,4 @@
+'\" t
 .TH RASPIREV 7
 .
 .SH NAME

--- a/vcmailbox/vcmailbox.7
+++ b/vcmailbox/vcmailbox.7
@@ -1,3 +1,4 @@
+'\" t
 .TH VCMAILBOX 7
 .
 .SH NAME


### PR DESCRIPTION
Since groff 1.23, lintian warns that table macros (`TS`, `TE`) are included without certain settings, which generated by the [tbl(1)](https://manpages.debian.org/bookworm/groff-base/tbl.1.en.html) pre-processor. Include a header indicating that the tbl(1) pre-processor should be run for all files that include tables.