### PR TITLE
Fix lintian warning about bash-completion shebangs

### DIFF
--- a/pinctrl/pinctrl-completion.bash
+++ b/pinctrl/pinctrl-completion.bash
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 _pinctrl ()
 {
     local cur prev words cword split cmd pins pincomp ALLPINS CHIPS chip pinmode=false prefix arg i func pull;


### PR DESCRIPTION
Lintian warns using a shebang in a bash-completion script. While I don't think they do any particular harm, it is redundant.

Incidentally, the reason I was looking into this was for including raspi-utils in Ubuntu. During this process, the build initially broke on `dh_missing` warning that the completions weren't being included in the final built package. Might be worth adding the following lines to `debian/raspi-utils-core.install`:

```
usr/share/bash-completion/completions/pinctrl
usr/share/bash-completion/completions/vcgencmd
```