### PR TITLE
ovmerge: Aligns the numbering of overlay param values to renumbered fragments.

### DIFF
--- a/ovmerge/ovmerge
+++ b/ovmerge/ovmerge
@@ -1785,9 +1785,9 @@ sub renumber_fragments
 
 	foreach my $ovr (@{$overrides->[1]})
 	{
-		for (my $pos = 1; $pos < @$ovr; $pos++)
+		for (my $pos = 1; ($pos + 1) < @$ovr; $pos++)
 		{
-			if ((get_label_ref($ovr->[$pos]) || '') eq '0')
+			if ((get_label_ref($ovr->[$pos]) // '') eq '0')
 			{
 				$pos++;
 				while ($ovr->[$pos]->[1] =~ /\G[=!+-](\d+)/g)


### PR DESCRIPTION
I noticed that the fragment numbering in the overlay is not updated when the renumbering is done.

E.g. Suppose you have a `fragment@23 ...` as fragment and a `something = "+23"` in the overlay section. The `ovmerge` will assign a new number to the fragment (for example 7) but the `something` configuration is still on `"+23"`. This patch corrects the situation, thus the overlay will be merged as `something = "+7"`.

cf. https://github.com/raspberrypi/documentation/blob/develop/documentation/asciidoc/computers/configuration/device-tree.adoc#overlayfragment-parameters