### PR TITLE
piolib: fixes may be used uninitialized

### DIFF
--- a/piolib/examples/quadrature_encoder.pio.h
+++ b/piolib/examples/quadrature_encoder.pio.h
@@ -94,7 +94,7 @@ static inline void quadrature_encoder_program_init(PIO pio, uint sm, uint pin, i
 }
 static inline int32_t quadrature_encoder_get_count(PIO pio, uint sm)
 {
-    uint ret;
+    uint ret = 0;
     int n;
     // if the FIFO has N entries, we fetch them to drain the FIFO,
     // plus one entry which will be guaranteed to not be stale


### PR DESCRIPTION
Fixes compile error:
```
In function 'quadrature_encoder_get_count',
    inlined from 'main' at /build/bcm2835-utils/piolib/examples/quadrature_encoder.c:58:21:
/build/bcm2835-utils/piolib/examples/quadrature_encoder.pio.h:106:12: error: 'ret' may be used uninitialized [-Werror=maybe-uninitialized]
  106 |     return ret;
      |            ^~~
``` 