### PR TITLE
piolib: Correct transfer return values

### DIFF
--- a/piolib/examples/apitest.c
+++ b/piolib/examples/apitest.c
@@ -184,7 +184,14 @@ int main(int argc, const char **argv) {
         pio_panic("RX FIFO is not empty");
 
     offset = pio_add_program(pio, &genseq_program);
-    pio_sm_config_xfer(pio, sm, PIO_DIR_FROM_SM, 4096, 2);
+
+    if (!pio_sm_config_xfer(pio, sm, PIO_DIR_FROM_SM, 4096, 0))
+        pio_panic("DMA configuration didn't fail");
+    if (!pio_sm_xfer_data(pio, sm, PIO_DIR_FROM_SM, 4, NULL) ||
+        !pio_sm_xfer_data(pio, sm, PIO_DIR_FROM_SM, 0, databuf))
+        pio_panic("DMA transfer didn't fail");
+    if (pio_sm_config_xfer(pio, sm, PIO_DIR_FROM_SM, 4096, 2))
+        pio_panic("DMA configuration failed");
 
     pio_gpio_init(pio, gpio);
     pio_sm_set_consecutive_pindirs(pio, sm, gpio, 1, true);

--- a/piolib/pio_rp1.c
+++ b/piolib/pio_rp1.c
@@ -256,10 +256,8 @@ static int rp1_ioctl(PIO pio, int request, void *args)
 static int rp1_pio_sm_config_xfer(PIO pio, uint sm, uint dir, uint buf_size, uint buf_count)
 {
     struct rp1_pio_sm_config_xfer_args args = { .sm = sm, .dir = dir, .buf_size = buf_size, .buf_count = buf_count };
-    int err;
     check_sm_param(sm);
-    err = rp1_ioctl(pio, PIO_IOC_SM_CONFIG_XFER, &args);
-    return (err > 0);
+    return rp1_ioctl(pio, PIO_IOC_SM_CONFIG_XFER, &args);
 }
 
 static int rp1_pio_sm_xfer_data(PIO pio, uint sm, uint dir, uint data_bytes, void *data)
@@ -272,7 +270,7 @@ static int rp1_pio_sm_xfer_data(PIO pio, uint sm, uint dir, uint data_bytes, voi
         err = rp1_ioctl(pio, PIO_IOC_SM_XFER_DATA32, &args32);
     else
         err = rp1_ioctl(pio, PIO_IOC_SM_XFER_DATA, &args);
-    return (err > 0);
+    return err;
 }
 
 static bool rp1_pio_can_add_program_at_offset(PIO pio, const pio_program_t *program, uint offset)


### PR DESCRIPTION
rp1_pio_sm_config_xfer and rp1_pio_sm_xfer_data both return either 1 or
0, despite not being declared as returning a bool. This is due to copy/
paste errors - they should simply return the int return value of the
underlying ioctl.

Fixes: https://github.com/raspberrypi/utils/issues/112

Also extend apitest to catch this.