### PR TITLE
piolib: Support larger DMA buffers

### DIFF
--- a/piolib/include/rp1_pio_if.h
+++ b/piolib/include/rp1_pio_if.h
@@ -160,6 +160,13 @@ struct rp1_pio_sm_config_xfer_args {
     uint16_t buf_count;
 };
 
+struct rp1_pio_sm_config_xfer32_args {
+    uint16_t sm;
+    uint16_t dir;
+    uint32_t buf_size;
+    uint32_t buf_count;
+};
+
 struct rp1_pio_sm_xfer_data_args {
     uint16_t sm;
     uint16_t dir;
@@ -186,6 +193,7 @@ struct rp1_access_hw_args {
 #define PIO_IOC_SM_CONFIG_XFER _IOW(PIO_IOC_MAGIC, 0, struct rp1_pio_sm_config_xfer_args)
 #define PIO_IOC_SM_XFER_DATA _IOW(PIO_IOC_MAGIC, 1, struct rp1_pio_sm_xfer_data_args)
 #define PIO_IOC_SM_XFER_DATA32 _IOW(PIO_IOC_MAGIC, 2, struct rp1_pio_sm_xfer_data32_args)
+#define PIO_IOC_SM_CONFIG_XFER32 _IOW(PIO_IOC_MAGIC, 3, struct rp1_pio_sm_config_xfer32_args)
 
 #define PIO_IOC_READ_HW _IOW(PIO_IOC_MAGIC, 8, struct rp1_access_hw_args)
 #define PIO_IOC_WRITE_HW _IOW(PIO_IOC_MAGIC, 9, struct rp1_access_hw_args)

--- a/piolib/pio_rp1.c
+++ b/piolib/pio_rp1.c
@@ -256,8 +256,14 @@ static int rp1_ioctl(PIO pio, int request, void *args)
 static int rp1_pio_sm_config_xfer(PIO pio, uint sm, uint dir, uint buf_size, uint buf_count)
 {
     struct rp1_pio_sm_config_xfer_args args = { .sm = sm, .dir = dir, .buf_size = buf_size, .buf_count = buf_count };
+    struct rp1_pio_sm_config_xfer32_args args32 = { .sm = sm, .dir = dir, .buf_size = buf_size, .buf_count = buf_count };
+    int err;
     check_sm_param(sm);
-    return rp1_ioctl(pio, PIO_IOC_SM_CONFIG_XFER, &args);
+    if (buf_size > 0xffff || buf_count > 0xffff)
+        err = rp1_ioctl(pio, PIO_IOC_SM_CONFIG_XFER32, &args32);
+    else
+        err = rp1_ioctl(pio, PIO_IOC_SM_CONFIG_XFER, &args);
+    return err;
 }
 
 static int rp1_pio_sm_xfer_data(PIO pio, uint sm, uint dir, uint data_bytes, void *data)


### PR DESCRIPTION
Similar to the increase in supported transfer lengths, for performance reasons it may be helpful to allow larger DMA buffers. This requires an updated rp1-pio driver that supports the new ioctl messages, otherwise calls to pio_sm_config_xfer with buffer sizes of 65536 or larger will fail.