### PR TITLE
eeptools: Add the POWER_SUPPLY atom

### DIFF
--- a/eeptools/eepdump.c
+++ b/eeptools/eepdump.c
@@ -9,15 +9,17 @@
 static struct var_blob_t dt_atom, custom_atom;
 static struct vendor_info_d vinf;
 static struct gpio_map_d gpiomap;
+static struct power_supply_d supply;
 static const char *blob_prefix;
 
 static const char *atom_type_names[] ={
 		[ATOM_INVALID_TYPE] = "invalid",
-		[ATOM_VENDOR_TYPE] = "vendor type",
+		[ATOM_VENDOR_TYPE] = "vendor",
 		[ATOM_GPIO_TYPE] = "GPIO map",
 		[ATOM_DT_TYPE] = "DT overlay",
 		[ATOM_CUSTOM_TYPE] = "manufacturer custom data",
 		[ATOM_GPIO_BANK1_TYPE] = "GPIO map bank 1",
+		[ATOM_POWER_SUPPLY_TYPE] = "power supply",
 };
 
 static void dump_data(FILE *out, const uint8_t *data, int len)
@@ -163,6 +165,14 @@ static int read_bin(const char *in, const char *outf)
 
 			fprintf(out, "vendor \"%s\"   # length=%u\n", vinf.vstr, vinf.vslen);
 			fprintf(out, "product \"%s\"   # length=%u\n", vinf.pstr, vinf.pslen);
+			break;
+
+		case ATOM_POWER_SUPPLY_TYPE:
+			if (!eepio_atom_power_supply(&supply))
+				goto atom_read_err;
+
+			fprintf(out, "# power supply\n");
+			fprintf(out, "current_supply %u\n", supply.current_supply);
 			break;
 
 		case ATOM_GPIO_BANK1_TYPE:

--- a/eeptools/eeplib.c
+++ b/eeptools/eeplib.c
@@ -312,6 +312,12 @@ bool eepio_atom_vinf(struct vendor_info_d *vinf)
 	return !eepio_got_error();
 }
 
+bool eepio_atom_power_supply(struct power_supply_d *power)
+{
+	eepio_blob(power, POWER_SUPPLY_SIZE);
+	return !eepio_got_error();
+}
+
 bool eepio_atom_gpio(struct gpio_map_d *map)
 {
 	eepio_blob(map, GPIO_SIZE);

--- a/eeptools/eeplib.h
+++ b/eeptools/eeplib.h
@@ -14,6 +14,7 @@
 #define VENDOR_SIZE 22
 #define GPIO_SIZE 30
 #define GPIO_BANK1_SIZE 20
+#define POWER_SUPPLY_SIZE 4
 #define CRC_SIZE 2
 
 #define GPIO_MIN 2
@@ -40,6 +41,7 @@ enum atom_type_t
 	ATOM_DT_TYPE = 0x0003,
 	ATOM_CUSTOM_TYPE = 0x0004,
 	ATOM_GPIO_BANK1_TYPE = 0x0005,
+	ATOM_POWER_SUPPLY_TYPE = 0x0006,
 	ATOM_HINVALID_TYPE = 0xffff
 };
 
@@ -102,6 +104,12 @@ struct gpio_map_d
 	unsigned char pins[GPIO_COUNT];
 };
 
+/* Power supply atom data */
+struct power_supply_d
+{
+	uint32_t current_supply; /* In milliamps */
+};
+
 extern struct header_t eep_header;
 extern struct atom_t eep_atom_header;
 extern uint16_t eep_atom_crc;
@@ -113,6 +121,7 @@ bool eepio_atom_start(enum atom_type_t *ptype, uint32_t *pdlen);
 bool eepio_atom_vinf(struct vendor_info_d *vinf);
 bool eepio_atom_gpio(struct gpio_map_d *map);
 bool eepio_atom_gpio_bank1(struct gpio_map_d *map);
+bool eepio_atom_power_supply(struct power_supply_d *power);
 bool eepio_atom_var(struct var_blob_t *var);
 void eepio_atom_end(void);
 void eepio_clear_error(void);

--- a/eeptools/eeprom_settings.txt
+++ b/eeptools/eeprom_settings.txt
@@ -27,6 +27,9 @@ vendor "ACME Technology Company"
 # ASCII product string (max 255 characters)
 product "Special Sensor Board"
 
+# How much current the HAT+ can supply, in milliamps
+current_supply 0
+
 # Which Device Tree overlay to load
 dt_blob "acme-sensor"
 


### PR DESCRIPTION
The POWER_SUPPLY atom describes the ability of the HAT to supply power to the Pi. This is declared in the EEPROM settings text file using the current_supply property. The default value for current_supply is zero, and unless a non-zero value is provided then the POWER_SUPPLY atom is omitted from the EEPROM image.