### PR TITLE
pinctrl: Create and use gpiolib library

### DIFF
--- a/pinctrl/CMakeLists.txt
+++ b/pinctrl/CMakeLists.txt
@@ -6,7 +6,13 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")
 #set project name
 project(pinctrl)
 
+add_compile_definitions(LIBRARY_BUILD=1)
+
+add_library(gpiolib STATIC gpiolib.c util.c library_gpiochips.c gpiochip_bcm2835.c gpiochip_bcm2712.c gpiochip_rp1.c)
+
 #add executables
-add_executable(pinctrl pinctrl.c gpiolib.c util.c gpiochip_bcm2835.c gpiochip_bcm2712.c gpiochip_rp1.c)
+add_executable(pinctrl pinctrl.c)
+target_link_libraries(pinctrl gpiolib)
 install(TARGETS pinctrl RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS gpiolib ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES pinctrl-completion.bash RENAME pinctrl DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/bash-completion/completions")

--- a/pinctrl/gpiochip.h
+++ b/pinctrl/gpiochip.h
@@ -3,9 +3,14 @@
 
 #include "gpiolib.h"
 
+#if LIBRARY_BUILD
+#define DECLARE_GPIO_CHIP(name, compatible, iface, size, data) \
+    const GPIO_CHIP_T name ## _chip = { #name, compatible, iface, size, data }
+#else
 #define DECLARE_GPIO_CHIP(name, compatible, iface, size, data) \
     const GPIO_CHIP_T name ## _chip = { #name, compatible, iface, size, data }; \
     const GPIO_CHIP_T *name ## _chip_ptr __attribute__ ((section ("gpiochips"))) __attribute__ ((used)) = &(name ## _chip)
+#endif
 
 typedef struct GPIO_CHIP_INTERFACE_ GPIO_CHIP_INTERFACE_T;
 
@@ -36,7 +41,12 @@ struct GPIO_CHIP_INTERFACE_
     const char * (*gpio_get_fsel_name)(void *priv, uint32_t gpio, GPIO_FSEL_T fsel);
 };
 
+#if LIBRARY_BUILD
+extern const GPIO_CHIP_T *const library_gpiochips[];
+extern const int library_gpiochips_count;
+#else
 extern const GPIO_CHIP_T *__start_gpiochips;
 extern const GPIO_CHIP_T *__stop_gpiochips;
+#endif
 
 #endif

--- a/pinctrl/gpiochip_bcm2712.c
+++ b/pinctrl/gpiochip_bcm2712.c
@@ -9,8 +9,6 @@
 #include "gpiochip.h"
 #include "util.h"
 
-#define ARRAY_SIZE(_a) (sizeof(_a)/sizeof(_a[0]))
-
 /* 2712 definitions */
 
 #define BCM2712_GIO_DATA       0x04

--- a/pinctrl/gpiochip_bcm2835.c
+++ b/pinctrl/gpiochip_bcm2835.c
@@ -8,8 +8,6 @@
 #include "gpiochip.h"
 #include "util.h"
 
-#define ARRAY_SIZE(_a) (sizeof(_a)/sizeof(_a[0]))
-
 #define BCM2835_NUM_GPIOS 54
 #define BCM2835_ALT_COUNT 6
 

--- a/pinctrl/gpiolib.c
+++ b/pinctrl/gpiolib.c
@@ -12,8 +12,6 @@
 #include "gpiochip.h"
 #include "util.h"
 
-#define ARRAY_SIZE(_a) (sizeof(_a)/sizeof(_a[0]))
-
 #define MAX_GPIO_CHIPS 8
 
 typedef struct GPIO_CHIP_INSTANCE_
@@ -394,9 +392,16 @@ const char *gpio_get_drive_name(GPIO_DRIVE_T drive)
 
 static const GPIO_CHIP_T *gpio_find_chip(const char *name)
 {
-    const GPIO_CHIP_T **chip_ptr;
+#if LIBRARY_BUILD
+    const GPIO_CHIP_T *const *start = &library_gpiochips[0];
+    const GPIO_CHIP_T *const *end = &library_gpiochips[0] + library_gpiochips_count;
+#else
+    const GPIO_CHIP_T *const *start = &__start_gpiochips;
+    const GPIO_CHIP_T *const *end = &__stop_gpiochips;
+#endif
+    const GPIO_CHIP_T *const *chip_ptr;
 
-    for (chip_ptr = &__start_gpiochips; name && chip_ptr < &__stop_gpiochips; chip_ptr++) {
+    for (chip_ptr = start; name && chip_ptr < end; chip_ptr++) {
         const GPIO_CHIP_T *chip = *chip_ptr;
         if (!strcmp(name, chip->name) ||
             !strcmp(name, chip->compatible))

--- a/pinctrl/library_gpiochips.c
+++ b/pinctrl/library_gpiochips.c
@@ -1,0 +1,20 @@
+#include "gpiochip.h"
+#include "util.h"
+
+#define GPIO_CHIP(name) name ## _chip
+#define EXTERN_GPIO_CHIP(name) extern const GPIO_CHIP_T GPIO_CHIP(name)
+
+EXTERN_GPIO_CHIP(bcm2835);
+EXTERN_GPIO_CHIP(bcm2711);
+EXTERN_GPIO_CHIP(bcm2712);
+EXTERN_GPIO_CHIP(rp1);
+
+const GPIO_CHIP_T *const library_gpiochips[] =
+{
+    &GPIO_CHIP(bcm2835),
+    &GPIO_CHIP(bcm2711),
+    &GPIO_CHIP(bcm2712),
+    &GPIO_CHIP(rp1),
+};
+
+const int library_gpiochips_count = ARRAY_SIZE(library_gpiochips);

--- a/pinctrl/util.h
+++ b/pinctrl/util.h
@@ -1,11 +1,13 @@
 #ifndef _UTIL_H
 #define _UTIL_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #define INVALID_ADDRESS ((uint64_t)~0)
 #define ROUND_UP(n, d) ((((n) + (d) - 1) / (d)) * (d))
 #define UNUSED(x) (void)(x)
+#define ARRAY_SIZE(_a) (sizeof(_a)/sizeof(_a[0]))
 
 typedef struct dt_subnode_iter *DT_SUBNODE_HANDLE;
 char *read_text_file(const char *fname, size_t *plen);


### PR DESCRIPTION
Create the gpiolib library to contain all of the gpiolib code and the gpiochips, so that applications such as pinctrl are just linked against it, and not all of the individual object files. The named section approach to collecting the gpiochips does not work in this situation, so add an explicit array of pointers to the gpiochip implementations.