### PR TITLE
Added opt-in option for cmake to create shared instead of static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.1...3.27)
 
 project(utils)
 
+option(BUILD_SHARED "Build as shared library" OFF)
+
 # List of subsidiary CMakeLists
 add_subdirectory(dtmerge)
 add_subdirectory(eeptools)

--- a/dtmerge/CMakeLists.txt
+++ b/dtmerge/CMakeLists.txt
@@ -11,7 +11,12 @@ if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)
 endif ()
 
-add_library (dtovl STATIC dtoverlay.c)
+if(BUILD_SHARED)
+   add_library (dtovl SHARED dtoverlay.c)
+else()
+   add_library (dtovl STATIC dtoverlay.c)
+endif()
+
 target_link_libraries(dtovl fdt)
 
 add_executable(dtmerge dtmerge.c)

--- a/pinctrl/CMakeLists.txt
+++ b/pinctrl/CMakeLists.txt
@@ -8,7 +8,12 @@ project(pinctrl)
 
 add_compile_definitions(LIBRARY_BUILD=1)
 
-add_library(gpiolib STATIC gpiolib.c util.c library_gpiochips.c gpiochip_bcm2835.c gpiochip_bcm2712.c gpiochip_rp1.c)
+if(BUILD_SHARED)
+    add_library(gpiolib SHARED gpiolib.c util.c library_gpiochips.c gpiochip_bcm2835.c gpiochip_bcm2712.c gpiochip_rp1.c)
+else()
+    add_library(gpiolib STATIC gpiolib.c util.c library_gpiochips.c gpiochip_bcm2835.c gpiochip_bcm2712.c gpiochip_rp1.c)
+endif()
+
 target_sources(gpiolib PUBLIC gpiolib.h)
 set_target_properties(gpiolib PROPERTIES PUBLIC_HEADER gpiolib.h)
 

--- a/piolib/CMakeLists.txt
+++ b/piolib/CMakeLists.txt
@@ -15,7 +15,12 @@ if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)
 endif ()
 
-add_library (pio STATIC piolib.c library_piochips.c pio_rp1.c)
+if(BUILD_SHARED)
+    add_library(pio SHARED piolib.c library_piochips.c pio_rp1.c)
+else()
+    add_library(pio STATIC piolib.c library_piochips.c pio_rp1.c)
+endif()
+
 target_include_directories(pio PUBLIC include)
 
 set(INCLUDE_FILES


### PR DESCRIPTION
#### Changes
  - dtmerge, pinctrl and piolib can now be built as shared libraries by executing ````cmake -D BUILD_SHARED=ON .````
  - If this option is not specified cmake will still default to the static libraries and work like it did before this change.