### PR TITLE
Optionally build shared libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,6 @@ A collection of scripts and simple applications
 Install the prerequisites with "sudo apt install cmake device-tree-compiler libfdt-dev" - you need at least version 3.10 of cmake. Run the following commands to build and install everything, or see the README files in the subdirectories to just build utilities individually:
 
  - *cmake .*
+    N.B. Use *cmake -DBUILD_SHARED_LIBS=1 .* to build the libraries in the subprojects (libdtovl, gpiolib and piolib) as shared (as opposed to static) libraries.
  - *make*
  - *sudo make install*

--- a/dtmerge/CMakeLists.txt
+++ b/dtmerge/CMakeLists.txt
@@ -11,8 +11,13 @@ if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)
 endif ()
 
-add_library (dtovl STATIC dtoverlay.c)
+add_library (dtovl dtoverlay.c)
 target_link_libraries(dtovl fdt)
+set_target_properties(dtovl PROPERTIES PUBLIC_HEADER dtoverlay.h)
+set_target_properties(dtovl PROPERTIES SOVERSION 0)
+install(TARGETS dtovl
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 add_executable(dtmerge dtmerge.c)
 target_link_libraries(dtmerge dtovl)

--- a/dtmerge/README.md
+++ b/dtmerge/README.md
@@ -12,6 +12,7 @@ dtparam is a tool for applying paramaters of the base Device Tree of a live syst
 Install the prerequisites with "sudo apt install cmake libfdt-dev" - you need at least version 3.10 of cmake. Run the following commands here, or in the top-level directory to build and install all the utilities:
 
  - *cmake .*
+    N.B. Use *cmake -DBUILD_SHARED_LIBS=1 .* to build libdtovl as a shared (as opposed to static) library.
  - *make*
  - *sudo make install*
 

--- a/pinctrl/CMakeLists.txt
+++ b/pinctrl/CMakeLists.txt
@@ -8,9 +8,10 @@ project(pinctrl)
 
 add_compile_definitions(LIBRARY_BUILD=1)
 
-add_library(gpiolib STATIC gpiolib.c util.c library_gpiochips.c gpiochip_bcm2835.c gpiochip_bcm2712.c gpiochip_rp1.c)
+add_library(gpiolib gpiolib.c util.c library_gpiochips.c gpiochip_bcm2835.c gpiochip_bcm2712.c gpiochip_rp1.c)
 target_sources(gpiolib PUBLIC gpiolib.h)
 set_target_properties(gpiolib PROPERTIES PUBLIC_HEADER gpiolib.h)
+set_target_properties(gpiolib PROPERTIES SOVERSION 0)
 
 #add executables
 add_executable(pinctrl pinctrl.c)

--- a/pinctrl/README.md
+++ b/pinctrl/README.md
@@ -23,6 +23,7 @@ The improvements over raspi-gpio include:
 Install the prerequisites with "sudo apt install cmake" - you need at least version 3.10 of cmake. Run the following commands, either here or in the top-level directory to build and install everything:
 
  - *cmake .*
+   N.B. Use *cmake -DBUILD_SHARED_LIBS=1 .* to build gpiolib as a shared (as opposed to static) library.
  - *make*
  - *sudo make install*
 

--- a/piolib/CMakeLists.txt
+++ b/piolib/CMakeLists.txt
@@ -15,8 +15,9 @@ if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)
 endif ()
 
-add_library (pio STATIC piolib.c library_piochips.c pio_rp1.c)
+add_library (pio piolib.c library_piochips.c pio_rp1.c)
 target_include_directories(pio PUBLIC include)
+set_target_properties(pio PROPERTIES SOVERSION 0)
 
 set(INCLUDE_FILES
     "piolib.h"

--- a/piolib/README.md
+++ b/piolib/README.md
@@ -7,6 +7,7 @@ PIOlib/libPIO is a user-space API to the rp1-pio driver, which gives access to t
 Install the prerequisites with `sudo apt install build-essential cmake` - you need at least version 3.10 of cmake. Run the following commands, either here or in the top-level directory to build and install everything:
 
 1. `cmake .` (or create a build subdirectory and run `cmake ..`)
+    N.B. Use *cmake -DBUILD_SHARED_LIBS=1 .* to build piolib as a shared (as opposed to static) library.
 2. `make`
 
 If `ls -l /dev/pio0` reports that the file is not found, you may need to update your Pi 5 firmware to one with PIO support and make sure that you are running a suitably recent kernel.


### PR DESCRIPTION
Previously the subprojects with libraries as targets build them as static (.a) libraries. Add the option of building them as shared libraries by making use of the standard BUILD_SHARED_LIBS option.

This is a simpler version of https://github.com/raspberrypi/utils/pull/128, which was a useful prod.