### PR TITLE
Update raspinfo: correct heading text

### DIFF
--- a/raspinfo/raspinfo
+++ b/raspinfo/raspinfo
@@ -229,8 +229,8 @@ echo
 audio_info
 
 echo
-echo "config.txt"
-echo "----------"
+echo "Firmware Configuration"
+echo "----------------------"
 echo
 
 #cat /boot/config.txt | egrep -v "^\s*(#|^$)"


### PR DESCRIPTION
The section labelled config.txt actually outputs the firmware configuration reported by vcgencmd get_config int and str. Change the section heading to reflect this.