### PR TITLE
eeptools: Fix flash example

### DIFF
--- a/eeptools/README.md
+++ b/eeptools/README.md
@@ -56,7 +56,7 @@ Follow these steps on the Raspberry Pi after installing the tools and building t
 	   70:
 	```
 	Normally, you can skip this step, and assume things are working.
-3. Flash eep file `sudo ./eepflash.sh -w -t=24c32 -a=0x50 -f=eeprom.eep`
+3. Flash eep file `sudo ./eepflash.sh -w -t=24c32 -a=50 -f=eeprom.eep`
 4. Enable EEPROM write protection, by undoing step 1 (putting back jumper, or resetting GPIO)
 
 ## String data formatting


### PR DESCRIPTION
Did the kernel change device enumeration?

With `-a=0x50`:

```sh
# ./eeptools/eepflash.sh -w -t=24c32 -a=50 -f=foo.eep
This will attempt to talk to an eeprom at i2c address 0x0x50. Make sure there is an eeprom at this address.
This script comes with ABSOLUTELY no warranty. Continue only if you know what you are doing.
Do you wish to continue? (yes/no): yes
./eeptools/eepflash.sh: 161: echo: echo: I/O error
Writing...
dd: failed to open '/sys/class/i2c-dev/i2c-9/device/9-000x50/eeprom': No such file or directory
Closing EEPROM Device.
./eeptools/eepflash.sh: 189: echo: echo: I/O error
Error doing I/O operation.
```

With `-a=50`:

```sh
# ./eeptools/eepflash.sh -w -t=24c32 -a=50 -f=foo.eep
This will attempt to talk to an eeprom at i2c address 0x50. Make sure there is an eeprom at this address.
This script comes with ABSOLUTELY no warranty. Continue only if you know what you are doing.
Do you wish to continue? (yes/no): yes
Writing...
Closing EEPROM Device.
Done.
```

Raspberry 5
Operating System: Debian GNU/Linux 12 (bookworm)  
Kernel: Linux 6.12.38-v8-16k+
```sh
# rpi-eeprom-update 
BOOTLOADER: up to date
   CURRENT: Thu 17 Jul 16:25:12 UTC 2025 (1752769512)
    LATEST: Thu 17 Jul 16:25:12 UTC 2025 (1752769512)
   RELEASE: latest (/usr/lib/firmware/raspberrypi/bootloader-2712/latest)
            Use raspi-config to change the release.
```