### PR TITLE
rpifwcrypto: Only build rpifwcrypto if libgnutls28-dev is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,4 +15,12 @@ add_subdirectory(raspinfo)
 add_subdirectory(vcgencmd)
 add_subdirectory(vclog)
 add_subdirectory(vcmailbox)
-add_subdirectory(rpifwcrypto)
+
+# Only build rpifwcrypto if GnuTLS is available
+include(CheckIncludeFile)
+check_include_file(gnutls/crypto.h HAVE_GNUTLS_CRYPTO_H)
+if(HAVE_GNUTLS_CRYPTO_H)
+    add_subdirectory(rpifwcrypto)
+else()
+    message(STATUS "gnutls/crypto.h not found - skipping rpifwcrypto")
+endif()


### PR DESCRIPTION
The addition of the rpifwcrypto means that this projects now depends on GNU TLS. Since this package may not be installed by default make rpifwcrypto and optional component for the moment and only build it if libgnutls28-dev is installed.

See: https://github.com/raspberrypi/utils/issues/140