### PR TITLE
rpifwcrypto: Add genkey command

### DIFF
--- a/rpifwcrypto/rpifwcrypto.h
+++ b/rpifwcrypto/rpifwcrypto.h
@@ -24,7 +24,8 @@ typedef enum {
     RPI_FW_CRYPTO_KEY_NOT_SET = 6,         // Key is all zeros
     RPI_FW_CRYPTO_KEY_INVALID = 7,         // Invalid key type/format
     RPI_FW_CRYPTO_NOT_SUPPORTED = 8,       // Requested operation is not supported
-    RPI_FW_CRYPTO_OPERATION_FAILED = 9     // Crypto algorithm error
+    RPI_FW_CRYPTO_OPERATION_FAILED = 9,    // Crypto algorithm error
+    RPI_FW_CRYPTO_KEY_NOT_BLANK = 10,      // Key slot is not blank
 } RPI_FW_CRYPTO_STATUS;
 
 /**
@@ -126,6 +127,17 @@ int rpi_fw_crypto_get_private_key(uint32_t flags, uint32_t key_id, uint8_t *priv
  * @return A constant string describing the key status
  */
 const char *rpi_fw_crypto_key_status_str(uint32_t key_status);
+
+/**
+ * Generates an ECDSA in the specified key slot.
+ *
+ * The key-slot must be unlocked and blank.
+ *
+ * @param flags Operation flags (currently unused, set to 0)
+ * @param key_id The ID of the key to use
+ * @return 0 on success, negative error code on failure
+ */
+int rpi_fw_crypto_gen_ecdsa_key(uint32_t flags, uint32_t key_id);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add support for the new genkey firmware API which can generates an ECDSA P-256 private key and writes it to the OTP slot for the device unique private key.

It is intended that this should be the primary method for generating the device unique private key. A future change may extend the flags to create and automatically lock this key.