### PR TITLE
readme: Add libcurses-dev to the dependencies for rpi-gpu-usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A collection of scripts and simple applications
 
 **Build Instructions**
 
-Install the prerequisites with "sudo apt install cmake device-tree-compiler libfdt-dev libgnutls28-dev" - you need at least version 3.10 of cmake. Run the following commands to build and install everything, or see the README files in the subdirectories to just build utilities individually:
+Install the prerequisites with "sudo apt install cmake device-tree-compiler libncurses-dev libfdt-dev libgnutls28-dev" - you need at least version 3.10 of cmake. Run the following commands to build and install everything, or see the README files in the subdirectories to just build utilities individually:
 
  - *cmake .*
     N.B. Use *cmake -DBUILD_SHARED_LIBS=1 .* to build the libraries in the subprojects (libdtovl, gpiolib and piolib) as shared (as opposed to static) libraries.


### PR DESCRIPTION
rpi-gpu-usage depends upon libcurses-dev which is not installed by default on RPi OS. Update the build instructions to include this in the dependencies.