### PR TITLE
rpifwcrypto: Check ioctl return code first and clarify bit31 handling

### DIFF
--- a/rpifwcrypto/rpifwcrypto.c
+++ b/rpifwcrypto/rpifwcrypto.c
@@ -23,8 +23,11 @@
 /* Mailbox channel for property interface */
 #define MBOX_CHAN_PROPERTY 8
 
-/* VideoCore mailbox error flag */
-#define VC_MAILBOX_ERROR 0x80000000
+/* VideoCore mailbox error flag, by convention set on status 0 of property */
+#define VC_MAILBOX_ERROR     0x80000000
+
+/* VideoCore sets most significant bit to indicate that the code/len has been set by the firmware */
+#define VC_MAILBOX_COMPLETE  0x80000000
 
 /* Crypto-related mailbox tags */
 typedef enum {
@@ -152,8 +155,10 @@ static int mbox_property(int file_desc, void *msg)
 {
     struct firmware_msg_header *hdr = (struct firmware_msg_header *)msg;
     int rc = ioctl(file_desc, IOCTL_MBOX_PROPERTY, msg);
-    if (rc < 0)
+    if (rc < 0) {
         fprintf(stderr, "ioctl_mbox_property failed: %d\n", rc);
+        return rc;
+    }
 
     LOG_DEBUG("msg.hdr.code: %08x\n", hdr->code);
     LOG_DEBUG("msg.hdr.buf_size: %d\n", hdr->buf_size);
@@ -161,8 +166,8 @@ static int mbox_property(int file_desc, void *msg)
     LOG_DEBUG("msg.hdr.tag_buf_size: %d\n", hdr->tag_buf_size);
     LOG_DEBUG("msg.hdr.tag_req_resp_size: %d\n", hdr->tag_req_resp_size);
 
-    if (!(hdr->code & VC_MAILBOX_ERROR) ||
-        !(hdr->tag_req_resp_size & VC_MAILBOX_ERROR))
+    if (!(hdr->code & VC_MAILBOX_COMPLETE) ||
+        !(hdr->tag_req_resp_size & VC_MAILBOX_COMPLETE))
         return -1;
 
     return 0;


### PR DESCRIPTION
Update the mbox_property handler to check the ioctl message first before looking at the tags. Otherwise, there's a small risk that if the first argument had bit31 set and the mailbox did not complete then this would be treated as success.

Clarify usage of bit31. This is set by VC to indicate that the mailbox property has been processed and the return length is set.

Setting the in/out arg[0] property of the property to VC_MAILBOX_ERROR is by convention (but not always) used to indicate the property is not valid. The API allows multiple properties to be set in a single message (e.g. for display) but that feature is not used here.