### PR TITLE
dtoverlay: allow fragment enable/disable to work with strings

### DIFF
--- a/dtmerge/dtoverlay.c
+++ b/dtmerge/dtoverlay.c
@@ -1822,6 +1822,8 @@ int dtoverlay_override_one_target(int override_type,
                 override_int = 0;
             else if (strcmp(override_value, "up") == 0)
                 override_int = 2;
+            else if (override_type == DTOVERRIDE_OVERLAY)
+                override_int = (strlen(override_value) != 0); /* allow non-empty strings to enable/disable fragments */
             else
             {
                 dtoverlay_error("invalid override value '%s' - ignored",


### PR DESCRIPTION
This patch allows enabling/disabling fragments when the parameter is a string (fixes #182).  Intentionally simplified example:
```
/ {
	fragment_handle: fragment@1 {
		__dormant__ {
			status = "okay";
		};
	};
	__overrides__ {
		node-name =
			<0>,"+1"
		,
			<&fragment_handle>,"target-path"
		;
};
```
which allows a node to be enabled by alias or node path across a variety of systems (where a list of handles may be invalid):
```
dtmerge dtb dtb enable-node node-name=ALIAS
dtmerge dtb dtb enable-node node-name=/FULL/PATH/TO/NODE
```