### PR TITLE
raspinfo: Add eee info and network statistics

### DIFF
--- a/raspinfo/raspinfo
+++ b/raspinfo/raspinfo
@@ -167,6 +167,20 @@ audio_info() {
    fi
 }
 
+network_info() {
+   ifconfig | sed -e "s/\([0-9a-fA-F]\{1,4\}:\)\{7,7\}[0-9a-fA-F]\{1,4\}/y.y.y.y.y.y.y.y/g" | sed -e "s/[0-9a-fA-F]\{1,4\}:\(:[0-9a-fA-F]\{1,4\}\)\{1,4\}/y::y.y.y.y/g" | sed -e "s/\([0-9]\{1,3\}\.\)\{3,3\}[0-9]\{1,3\}/x.x.x.x/g" | sed -e "s/\([0-9a-fA-F]\{2,2\}\:\)\{5,5\}[0-9a-fA-F]\{2,2\}/m.m.m.m/g"
+   echo
+   if command -v ethtool > /dev/null; then
+      ethtool eth0
+      echo
+      ethtool --show-eee eth0
+      echo
+      ethtool -S eth0
+   else
+      echo "ethtool not installed"
+   fi
+}
+
 OUT=raspinfo.txt
 
 rm -f $OUT
@@ -239,7 +253,7 @@ echo "Networking Information"
 echo "----------------------"
 echo
 
-ifconfig | sed -e "s/\([0-9a-fA-F]\{1,4\}:\)\{7,7\}[0-9a-fA-F]\{1,4\}/y.y.y.y.y.y.y.y/g" | sed -e "s/[0-9a-fA-F]\{1,4\}:\(:[0-9a-fA-F]\{1,4\}\)\{1,4\}/y::y.y.y.y/g" | sed -e "s/\([0-9]\{1,3\}\.\)\{3,3\}[0-9]\{1,3\}/x.x.x.x/g" | sed -e "s/\([0-9a-fA-F]\{2,2\}\:\)\{5,5\}[0-9a-fA-F]\{2,2\}/m.m.m.m/g"
+network_info
 
 echo
 echo "USB Information"


### PR DESCRIPTION
Recent debugging of the genet issue has shown that EEE state and interface counters are useful to have on hand. Add them to raspinfo.