### PR TITLE
rpi-fw-crypto: Set exit status to the firmware error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ A collection of scripts and simple applications
 Install the prerequisites with "sudo apt install cmake device-tree-compiler libncurses-dev libfdt-dev libgnutls28-dev" - you need at least version 3.10 of cmake. Run the following commands to build and install everything, or see the README files in the subdirectories to just build utilities individually:
 
  - *cmake .*
-    N.B. Use *cmake -DBUILD_SHARED_LIBS=1 .* to build the libraries in the subprojects (libdtovl, gpiolib and piolib) as shared (as opposed to static) libraries.
+    N.B. Use *cmake -DBUILD_SHARED_LIBS=1 .* to build the libraries in the subprojects (libdtovl, gpiolib and piolib) as shared (as opposed to static) libraries. Add -DCMAKE_INSTALL_PREFIX=/usr to override the default install path of /usr/local.
  - *make*
  - *sudo make install*

--- a/rpifwcrypto/main.c
+++ b/rpifwcrypto/main.c
@@ -516,6 +516,9 @@ error:
     // Check the firmware crypto error status. If set, display the human readable string.
     last_err = rpi_fw_crypto_get_last_error();
     if (last_err != RPI_FW_CRYPTO_SUCCESS)
+    {
         fprintf(stderr, "Last crypto error: %d (%s)\n", last_err, rpi_fw_crypto_strerror(last_err));
+        rc = -last_err;
+    }
     return rc;
 }


### PR DESCRIPTION
If the firmware has reported a failure then set the exit code to be -ve firmware_status. Other errors, e.g. argument parsing, are returned as -1 which is the same as FW_UNKNOWN_ERROR.

Setting the process exit status like this makes it easier for the PiConnect server to report more useful error information.

Also, add a hint about CMAKE install prefix because I can never remember CMake parameters.