### PR TITLE
vcgencmd: Increase size of vcgencmd results buffer

### DIFF
--- a/vcgencmd/vcgencmd.c
+++ b/vcgencmd/vcgencmd.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define VCIO_IOC_MAGIC 100
 #define IOCTL_MBOX_PROPERTY _IOWR(VCIO_IOC_MAGIC, 0, char *)
 
-#define MAX_STRING 1024
+#define MAX_STRING (4*1024)
 
 /*
  * use ioctl to send mbox property message


### PR DESCRIPTION
A fairly modest config.txt:
```
enable_uart=1
camera_auto_detect=1
display_auto_detect=1
max_framebuffers=2
disable_fw_kms_setup=1
disable_overscan=1
hdmi_ignore_cec_init=1
hdmi_enable_4kp60=1
arm_boost=1
arm_64bit=1
disable_fw_kms_setup=1
core_freq_min=250
v3d_freq_min=250
hevc_freq_min=250
h264_freq_min=250
isp_freq_min=250
```
gives an error when running:
```
$ vcgencmd get_config int
ioctl_set_msg failed:-1
```
Increasing the output buffer size fixes this