### PR TITLE
cmake: Add a -Werror build option for the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,8 @@ jobs:
         run: |
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_INSTALL_PREFIX=/usr
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DENABLE_WERROR=ON
 
       - name: Configure (armhf)
         if: matrix.arch == 'armhf'
@@ -61,6 +62,7 @@ jobs:
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_INSTALL_PREFIX=/usr \
+            -DENABLE_WERROR=ON \
             -DCMAKE_SYSTEM_NAME=Linux \
             -DCMAKE_SYSTEM_PROCESSOR=arm \
             -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.1...3.27)
 
 project(utils)
 
+option(ENABLE_WERROR "Treat compiler warnings as errors" OFF)
+
 # List of subsidiary CMakeLists
 add_subdirectory(dtmerge)
 add_subdirectory(eeptools)

--- a/dtmerge/CMakeLists.txt
+++ b/dtmerge/CMakeLists.txt
@@ -5,7 +5,11 @@ include(GNUInstallDirs)
 #set project name
 project(dtmerge)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+option(ENABLE_WERROR "Treat compiler warnings as errors" OFF)
+if(ENABLE_WERROR)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
 
 if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)

--- a/eeptools/CMakeLists.txt
+++ b/eeptools/CMakeLists.txt
@@ -5,7 +5,11 @@ include(GNUInstallDirs)
 #set project name
 project(eeptools)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+option(ENABLE_WERROR "Treat compiler warnings as errors" OFF)
+if(ENABLE_WERROR)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
 
 if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)

--- a/pinctrl/CMakeLists.txt
+++ b/pinctrl/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 include(GNUInstallDirs)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+option(ENABLE_WERROR "Treat compiler warnings as errors" OFF)
+if(ENABLE_WERROR)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
 
 #set project name
 project(pinctrl)

--- a/piolib/CMakeLists.txt
+++ b/piolib/CMakeLists.txt
@@ -9,7 +9,11 @@ project(piolib)
 
 add_compile_definitions(LIBRARY_BUILD=1)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+option(ENABLE_WERROR "Treat compiler warnings as errors" OFF)
+if(ENABLE_WERROR)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
 
 if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)

--- a/piolib/examples/CMakeLists.txt
+++ b/piolib/examples/CMakeLists.txt
@@ -5,7 +5,11 @@ include(GNUInstallDirs)
 #set project name
 project(examples)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+option(ENABLE_WERROR "Treat compiler warnings as errors" OFF)
+if(ENABLE_WERROR)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
 
 if (CMAKE_COMPILER_IS_GNUCC)
    add_definitions (-ffunction-sections)

--- a/rpieepromab/CMakeLists.txt
+++ b/rpieepromab/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 include(GNUInstallDirs)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+option(ENABLE_WERROR "Treat compiler warnings as errors" OFF)
+if(ENABLE_WERROR)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
 
 # Set project name and version
 project(rpieepromab VERSION 0.2.2)

--- a/rpifwcrypto/CMakeLists.txt
+++ b/rpifwcrypto/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 include(GNUInstallDirs)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+option(ENABLE_WERROR "Treat compiler warnings as errors" OFF)
+if(ENABLE_WERROR)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
 
 # Set project name
 project(rpifwcrypto)

--- a/vclog/CMakeLists.txt
+++ b/vclog/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.10...3.27)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic")
+option(ENABLE_WERROR "Treat compiler warnings as errors" OFF)
+if(ENABLE_WERROR)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
 
 #set project name
 project(vclog)


### PR DESCRIPTION
Move the -Werror flag from being the default to a CMake build flag - ENABLE_WERROR - and set it in the workflow.

Fixes: #69