### PR TITLE
ovmerge: allow top-level phandles to optionally be preserved

### DIFF
--- a/ovmerge/ovmerge
+++ b/ovmerge/ovmerge
@@ -304,6 +304,17 @@ foreach my $overlay (@ARGV)
 		foreach my $fragment (get_fragments($dt))
 		{
 			delete_node($fragment) if (get_child($fragment, '__dormant__'));
+
+			# Treat a dtoverlay,preserve-phandle property as an export of any label on the node
+			my $payload = get_child($fragment, '__overlay__');
+			if (get_prop($payload, "dtoverlay,preserve-phandle"))
+			{
+				foreach my $label (get_labels($payload))
+				{
+					adj_ref(1, $label);
+				}
+				delete_prop($payload, "dtoverlay,preserve-phandle");
+			}
 		}
 	}
 	$cur_dt = undef;


### PR DESCRIPTION
Look for the 'dtoverlay,preserve-phandle' flag in the overlay payloads, preserving the label on any payloads where it is present.

This is the ovmerge equivalent of
https://github.com/raspberrypi/utils/pull/198.