### PR TITLE
rpifwcrypto: Fine-grained locking

### DIFF
--- a/rpifwcrypto/README.md
+++ b/rpifwcrypto/README.md
@@ -65,8 +65,18 @@ rpi-fw-crypto get-key-status 1
 Block the raw OTP read API on key-id 1 until the device is rebooted:
 
 ```
-rpi-fw-crypto set-key-status 1 LOCKED
+rpi-fw-crypto set-key-status 1 READ_LOCKED
 ```
+
+All locks persist until the device is rebooted:
+
+| Flag | Description |
+|------|-------------|
+| `READ_LOCKED` | Blocks the raw OTP read API (`privkey`) |
+| `GEN_LOCKED` | Blocks key generation (`genkey`) |
+| `SIGN_LOCKED` | Blocks signing (`sign`) |
+| `HMAC_LOCKED` | Blocks HMAC (`hmac`) |
+| `USAGE_LOCKED` | Blocks setting the key usage (`set-key-usage`) |
 
 Get the usage of key-id 1:
 
@@ -115,12 +125,18 @@ Generate an ECDSA P256 key-pair and write the private key to the OTP:
 rpi-fw-crypto genkey --key-id 1 --alg ec
 ```
 
-## Locking the device private key
+## Locking at boot via config.txt
 
-Access to the device private key can be locked by default at boot by setting
-`lock_device_private_key=1` in config.txt. This blocks the raw OTP read API
-(`rpi-fw-crypto privkey`) for the key until the device is rebooted, whilst
-still allowing the sign, hmac and pubkey operations.
+Locks can be applied to every key by default at boot via config.txt
+and persist until the device is rebooted.
+
+`lock_device_private_key=1` blocks the raw OTP read API (`rpi-fw-crypto
+privkey`) for all keys, whilst still allowing the sign, hmac and
+pubkey operations.
+
+`lock_device_key_write=1` blocks both generating a key (`rpi-fw-crypto genkey`)
+and setting its usage (`rpi-fw-crypto set-key-usage`). This is equivalent to
+applying `GEN_LOCKED` and `USAGE_LOCKED` to every key.
 
 The contents of config.txt (within boot.img) is authenticated by the firmware
 if secure-boot is enabled and `lock_device_private_key=1` should always be

--- a/rpifwcrypto/main.c
+++ b/rpifwcrypto/main.c
@@ -22,9 +22,16 @@ static void usage(const char *progname)
         "  get-key-status <key-id>          Gets the status of a specified key\n"
         "     STATUS is a bitmask of the following flags:\n"
         "     - DEVICE - Key is the device unique private key\n"
-        "     - LOCKED - The key cannot be read raw format. LOCKED persists until reboot.\n"
+        "     - READ_LOCKED - The key cannot be read in raw format\n"
+        "     - GEN_LOCKED - Key generation is locked\n"
+        "     - SIGN_LOCKED - Signing operations are locked\n"
+        "     - HMAC_LOCKED - HMAC operations are locked\n"
+        "     - USAGE_LOCKED - Key usage updates are locked\n"
         "\n"
-        "  set-key-status <key-id> [LOCKED] Sets the status attributes for the specified key.\n"
+        "  set-key-status <key-id> <status> Sets the status attributes for the specified key\n"
+        "     that persists until reboot.\n"
+        "     Supported status strings: READ_LOCKED, GEN_LOCKED,\n"
+        "     SIGN_LOCKED, HMAC_LOCKED, USAGE_LOCKED\n"
         "\n"
         "  get-key-usage <key-id>           Gets the usage of a specified key\n"
         "\n"
@@ -297,8 +304,16 @@ static int parse_key_status_args(int argc, char *argv[], int start_idx, int *out
     int status = 0;
     int i;
     for (i = start_idx; i < argc; ++i) {
-        if (strcmp(argv[i], "LOCKED") == 0) {
-            status |= ARM_CRYPTO_KEY_STATUS_LOCKED;
+        if (strcmp(argv[i], "LOCKED") == 0 || strcmp(argv[i], "READ_LOCKED") == 0) {
+            status |= ARM_CRYPTO_KEY_STATUS_READ_LOCKED;
+        } else if (strcmp(argv[i], "GEN_LOCKED") == 0) {
+            status |= ARM_CRYPTO_KEY_STATUS_GEN_LOCKED;
+        } else if (strcmp(argv[i], "SIGN_LOCKED") == 0) {
+            status |= ARM_CRYPTO_KEY_STATUS_SIGN_LOCKED;
+        } else if (strcmp(argv[i], "HMAC_LOCKED") == 0) {
+            status |= ARM_CRYPTO_KEY_STATUS_HMAC_LOCKED;
+        } else if (strcmp(argv[i], "USAGE_LOCKED") == 0) {
+            status |= ARM_CRYPTO_KEY_STATUS_USAGE_LOCKED;
         } else {
             fprintf(stderr, "Unknown or unsupported key status string: %s\n", argv[i]);
             return -1;

--- a/rpifwcrypto/rpifwcrypto.c
+++ b/rpifwcrypto/rpifwcrypto.c
@@ -290,18 +290,42 @@ const char *rpi_fw_crypto_strerror(RPI_FW_CRYPTO_STATUS status)
 // Converts a key_status value to a human-readable string, e.g. "CUSTOMER LOCKED"
 const char *rpi_fw_crypto_key_status_str(uint32_t key_status)
 {
-    static char buf[64];
+    static char buf[100];
     buf[0] = '\0';
     uint32_t known = 0;
     if (key_status & ARM_CRYPTO_KEY_STATUS_TYPE_DEVICE_PRIVATE_KEY) {
         strcat(buf, "DEVICE");
         known |= ARM_CRYPTO_KEY_STATUS_TYPE_DEVICE_PRIVATE_KEY;
     }
-    if (key_status & ARM_CRYPTO_KEY_STATUS_LOCKED) {
+    if (key_status & ARM_CRYPTO_KEY_STATUS_READ_LOCKED) {
         if (buf[0])
             strcat(buf, " ");
-        strcat(buf, "LOCKED");
-        known |= ARM_CRYPTO_KEY_STATUS_LOCKED;
+        strcat(buf, "READ_LOCKED");
+        known |= ARM_CRYPTO_KEY_STATUS_READ_LOCKED;
+    }
+    if (key_status & ARM_CRYPTO_KEY_STATUS_GEN_LOCKED) {
+        if (buf[0])
+            strcat(buf, " ");
+        strcat(buf, "GEN_LOCKED");
+        known |= ARM_CRYPTO_KEY_STATUS_GEN_LOCKED;
+    }
+    if (key_status & ARM_CRYPTO_KEY_STATUS_SIGN_LOCKED) {
+        if (buf[0])
+            strcat(buf, " ");
+        strcat(buf, "SIGN_LOCKED");
+        known |= ARM_CRYPTO_KEY_STATUS_SIGN_LOCKED;
+    }
+    if (key_status & ARM_CRYPTO_KEY_STATUS_HMAC_LOCKED) {
+        if (buf[0])
+            strcat(buf, " ");
+        strcat(buf, "HMAC_LOCKED");
+        known |= ARM_CRYPTO_KEY_STATUS_HMAC_LOCKED;
+    }
+    if (key_status & ARM_CRYPTO_KEY_STATUS_USAGE_LOCKED) {
+        if (buf[0])
+            strcat(buf, " ");
+        strcat(buf, "USAGE_LOCKED");
+        known |= ARM_CRYPTO_KEY_STATUS_USAGE_LOCKED;
     }
     if (key_status & ~known) {
         if (buf[0])

--- a/rpifwcrypto/rpifwcrypto.h
+++ b/rpifwcrypto/rpifwcrypto.h
@@ -6,7 +6,11 @@ extern "C" {
 #endif
 
 #define ARM_CRYPTO_KEY_STATUS_TYPE_DEVICE_PRIVATE_KEY (1 << 0)
-#define ARM_CRYPTO_KEY_STATUS_LOCKED                  (1 << 8)
+#define ARM_CRYPTO_KEY_STATUS_READ_LOCKED             (1 << 8)
+#define ARM_CRYPTO_KEY_STATUS_GEN_LOCKED              (1 << 9)
+#define ARM_CRYPTO_KEY_STATUS_SIGN_LOCKED             (1 << 10)
+#define ARM_CRYPTO_KEY_STATUS_HMAC_LOCKED             (1 << 11)
+#define ARM_CRYPTO_KEY_STATUS_USAGE_LOCKED            (1 << 12)
 
 #define RPI_FW_CRYPTO_HMAC_MSG_MAX_SIZE     2048
 #define RPI_FW_CRYPTO_ECDSA_RESP_MAX_SIZE   128


### PR DESCRIPTION
Specific crypto operations per key can be locked until reboot.